### PR TITLE
Add Node interface and document supported languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,75 @@
 # WorldAlphabets
-A Python tool to get languages of the world.
+A tool to access alphabets of the world with Python and Node interfaces.
+
+## Supported Languages
+
+Alphabet JSON files are available for these ISO language codes
+(language names from [langcodes](https://pypi.org/project/langcodes/)):
+
+| Code | Language |
+|------|----------|
+| ar | Arabic |
+| ba | Bashkir |
+| ban | Balinese |
+| bax | Bamun |
+| be | Belarusian |
+| bg | Bulgarian |
+| bku | Buhid |
+| bn | Bangla |
+| bo | Tibetan |
+| bug | Buginese |
+| bya | Batak |
+| chr | Cherokee |
+| cop | Coptic |
+| cs | Czech |
+| de | German |
+| el | Greek |
+| en | English |
+| eo | Esperanto |
+| es | Spanish |
+| fr | French |
+| gez | Geez |
+| gu | Gujarati |
+| he | Hebrew |
+| hnn | Hanunoo |
+| hu | Hungarian |
+| hy | Armenian |
+| it | Italian |
+| jv | Javanese |
+| ka | Georgian |
+| kk | Kazakh |
+| km | Khmer |
+| kn | Kannada |
+| la | Latin |
+| lep | Lepcha |
+| lif | Limbu |
+| lis | Lisu |
+| lo | Lao |
+| mid | Mandaic |
+| ml | Malayalam |
+| mn | Mongolian |
+| my | Burmese |
+| nqo | N’Ko |
+| or | Odia |
+| pl | Polish |
+| rej | Rejang |
+| ru | Russian |
+| sam | Samaritan Aramaic |
+| saz | Saurashtra |
+| si | Sinhala |
+| su | Sundanese |
+| syr | Syriac |
+| ta | Tamil |
+| tbw | Tagbanwa |
+| te | Telugu |
+| th | Thai |
+| tl | Filipino |
+| tr | Turkish |
+| tt | Tatar |
+| uk | Ukrainian |
+| vai | Vai |
+| zh | Chinese |
+| zra | Kara (Korea) |
 
 ## Getting Started
 
@@ -53,6 +123,17 @@ from worldalphabets import load_alphabet
 alphabet = load_alphabet("en")
 print(alphabet.uppercase[:5])  # ['A', 'B', 'C', 'D', 'E']
 print(alphabet.frequency['e'])
+```
+
+To load the data in Node.js:
+
+```javascript
+const { loadAlphabet } = require('./index');
+
+loadAlphabet('en').then((alphabet) => {
+  console.log(alphabet.uppercase.slice(0, 5)); // ['A', 'B', 'C', 'D', 'E']
+  console.log(alphabet.frequency['e']);
+});
 ```
 
 ### Update letter frequencies

--- a/index.js
+++ b/index.js
@@ -1,0 +1,12 @@
+const fs = require('fs/promises');
+const path = require('path');
+
+const DATA_DIR = path.join(__dirname, 'data', 'alphabets');
+
+async function loadAlphabet(code) {
+  const filePath = path.join(DATA_DIR, `${code}.json`);
+  const content = await fs.readFile(filePath, 'utf8');
+  return JSON.parse(content);
+}
+
+module.exports = { loadAlphabet };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "worldalphabets",
+  "version": "0.1.0",
+  "description": "Simple Node interface to WorldAlphabets data",
+  "main": "index.js",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- list all supported languages in the README with names from `langcodes`
- provide a simple Node loader for alphabet JSON data
- document how to use the data from Node.js

## Testing
- `ruff check .`
- `mypy .`
- `node -e "const {loadAlphabet} = require('./index'); loadAlphabet('en').then(a => console.log(a.uppercase.slice(0,5)))"`
- `node -e "const {loadAlphabet} = require('./index'); loadAlphabet('en').then(a => console.log(a.frequency['e']))"`


------
https://chatgpt.com/codex/tasks/task_e_68a724a75a588327afe2d4b3a0845d26