### PR TITLE
feat: Convert project to use uv and add PyPI publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Upload Python Package
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  build-and-publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        run: pipx install uv
+
+      - name: Install dependencies
+        run: uv pip install '.[dev]'
+
+      - name: Run ruff
+        run: ruff check .
+
+      - name: Run mypy
+        run: mypy .
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ __pycache__/
 
 # External repositories
 external/
+
+# Build artifacts
+src/worldalphabets.egg-info/

--- a/README.md
+++ b/README.md
@@ -87,8 +87,19 @@ frequencies from the [Simia unigrams dataset](http://simia.net/letters/).
 
 ### Setup
 
+This project uses `uv` for dependency management. To set up the development
+environment:
+
 ```bash
-pip install -r requirements-dev.txt
+# Install uv
+pipx install uv
+
+# Create and activate a virtual environment
+uv venv
+source .venv/bin/activate
+
+# Install dependencies
+uv pip install -e '.[dev]'
 ```
 
 ### Extract alphabets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,18 @@ version = "0.1.0"
 readme = "README.md"
 requires-python = ">=3.11"
 
+dependencies = [
+    "langcodes>=3.3.0",
+    "language-data>=1.1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "ruff>=0.1.0",
+    "mypy>=1.0.0",
+    "build>=0.10.0",
+]
+
 [tool.ruff]
 line-length = 88
 target-version = "py311"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,0 @@
-ruff>=0.1.0
-mypy>=1.0.0
-langcodes[data]>=3.3.0

--- a/scripts/extract_alphabets.py
+++ b/scripts/extract_alphabets.py
@@ -11,7 +11,7 @@ import urllib.request
 from pathlib import Path
 from typing import Dict, List
 
-import langcodes
+import langcodes  # type: ignore[import-not-found]
 
 REPO_URL = "https://github.com/kalenchukov/Alphabet.git"
 REPO_PATH = Path("external/Alphabet")

--- a/scripts/generate_alphabet_from_locale.py
+++ b/scripts/generate_alphabet_from_locale.py
@@ -16,7 +16,7 @@ import urllib.request
 import zipfile
 
 try:  # optional dependency
-    from icu import (  # type: ignore[import-untyped]
+    from icu import (  # type: ignore[import-not-found]
         Collator,
         Locale,
         LocaleData,


### PR DESCRIPTION
- Migrated dependency management from requirements-dev.txt to pyproject.toml.
- Added a GitHub Action to publish the package to PyPI on new version tags.
- The GitHub Action now uses uv to install dependencies and runs ruff and mypy checks before publishing.
- Updated README.md with new setup instructions using uv.
- Added .egg-info to .gitignore.