### PR TITLE
Fix locale alphabet generation when CLDR data missing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,10 @@
 # Project Guidelines
 
+- This repository mixes Python and Node code.
+- Use `uv run` for Python scripts and checks.
 - Run `ruff check` and `mypy` on any Python files you modify.
+- Run `npm test` when JavaScript files are changed.
 - Keep lines under 88 characters when possible.
 - Store generated alphabet JSON under `data/alphabets/`.
 - Document significant script or data changes in `README.md`.
+

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ uv pip install -e '.[dev]'
 **Extract alphabets**
 
 ```bash
-python scripts/extract_alphabets.py
+uv run scripts/extract_alphabets.py
 ```
 
 The script clones the Java project and stores JSON files for every available
@@ -200,7 +200,7 @@ is available, frequency values default to zero and the language is recorded in
 **Update letter frequencies**
 
 ```bash
-python scripts/update_frequencies.py
+uv run scripts/update_frequencies.py
 ```
 
 This script downloads the `unigrams.zip` archive and rewrites each alphabet's
@@ -211,27 +211,27 @@ frequency mapping using the published counts.
 Derive an alphabet from an ICU locale's exemplar character set:
 
 ```bash
-python scripts/generate_alphabet_from_locale.py <code> --locale <locale> \
-  --set-type index
+uv run scripts/generate_alphabet_from_locale.py <code> --locale <locale>
 ```
 
-The script writes `data/alphabets/<code>.json`, using the locale's index
+The script writes `data/alphabets/<code>.json`, using the locale's standard
 exemplar set for the base letters and populating frequency values from the
-Simia unigrams dataset when available.
+Simia unigrams dataset when available. Locales without exemplar data are
+skipped.
 
 **Generate alphabets from unigrams**
 
 For languages present in the Simia dataset but missing here:
 
 ```bash
-python scripts/generate_alphabet_from_unigrams.py <code> --locale <locale> \
+uv run scripts/generate_alphabet_from_unigrams.py <code> --locale <locale> \
   --block <Unicode block>
 ```
 
 The script writes `data/alphabets/<code>.json`. To list missing codes:
 
 ```bash
-python scripts/missing_unigram_languages.py
+uv run scripts/missing_unigram_languages.py
 ```
 
 **Generate missing alphabets**
@@ -240,7 +240,7 @@ Create alphabet files for every language in the Simia unigrams dataset that
 does not yet have one:
 
 ```bash
-python scripts/generate_missing_alphabets.py --limit 10
+uv run scripts/generate_missing_alphabets.py --limit 10
 ```
 
 Omit `--limit` to process all missing languages. Each file is written under


### PR DESCRIPTION
## Summary
- document mixed Python/Node environment and recommend `uv run` for Python scripts
- skip locales that only provide basic Latin letters instead of outputting A–Z placeholders
- clarify README instructions for generating alphabets and note skipped locales

## Testing
- `uv run ruff check scripts/generate_alphabet_from_locale.py`
- `uv run mypy scripts/generate_alphabet_from_locale.py`
- `uv run scripts/generate_missing_alphabets.py --limit 5` *(fails: PyICU is required)*

------
https://chatgpt.com/codex/tasks/task_e_68a744af8000832786e4b4e2a0f3bc5f