### PR TITLE
fix: update node version in github workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm test


### PR DESCRIPTION
The `npm test` command was failing in the GitHub Actions workflow due to an outdated Node.js version. The error `TypeError: (0 , _os(...).availableParallelism) is not a function` indicates that the Node.js version being used did not support `os.availableParallelism()`.

This commit updates the Node.js version in the `.github/workflows/npm-publish.yml` file from `16.x` to `20.x` to resolve the issue.