### PR TITLE
fix(ci): Correct uv usage in PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,25 +16,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python and uv
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: "uv"
 
-      - name: Install uv
-        run: pipx install uv
+      - name: Create virtual environment
+        run: uv venv
 
       - name: Install dependencies
         run: uv pip install '.[dev]'
 
       - name: Run ruff
-        run: ruff check .
+        run: uv run ruff check .
 
       - name: Run mypy
-        run: mypy .
+        run: uv run mypy .
 
       - name: Build package
-        run: python -m build
+        run: uv run python -m build
 
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The PyPI publishing workflow was failing because it was attempting to use uv to install dependencies without a virtual environment.

This change updates the workflow to:
- Use the `setup-python` action with `cache: "uv"` to manage the uv installation and environment caching.
- Explicitly create a virtual environment using `uv venv`.
- Use `uv run` to execute checks and build the package within the created environment, following the guidance in AGENTS.md.