### PR TITLE
feat: Automate versioning from release tags

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Update version in package.json
+        run: |
+          VERSION=$(echo "${{ github.event.release.tag_name }}" | sed 's/^v//')
+          sed -i "s/\"version\": \"{{version}}\"/\"version\": \"$VERSION\"/g" package.json
       - uses: actions/setup-node@v3
         with:
           node-version: '20.x'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Update version in pyproject.toml
+        run: |
+          VERSION=$(echo "${{ github.ref_name }}" | sed 's/^v//')
+          sed -i "s/version = \"{{version}}\"/version = \"$VERSION\"/g" pyproject.toml
+
       - name: Set up Python and uv
         uses: actions/setup-python@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 # Virtual environments
 .venv/
 .env
+uv.lock
 
 # Tool caches
 .mypy_cache/
@@ -15,6 +16,7 @@ external/
 
 # Build artifacts
 src/worldalphabets.egg-info/
+/build/
 
 # Node
 node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "worldalphabets",
-  "version": "0.1.0",
+  "version": "{{version}}",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "worldalphabets",
-      "version": "0.1.0",
+      "version": "{{version}}",
+      "license": "MIT",
       "devDependencies": {
         "jest": "^30.0.5"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldalphabets",
-  "version": "0.1.0",
+  "version": "{{version}}",
   "description": "Simple Node interface to WorldAlphabets data",
   "main": "index.js",
   "type": "commonjs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "worldalphabets"
-version = "0.1.0"
+version = "{{version}}"
 readme = "README.md"
 requires-python = ">=3.11"
 


### PR DESCRIPTION
Replaces hardcoded version numbers in `package.json` and `pyproject.toml` with a `{{version}}` placeholder.

Updates the GitHub Actions workflows to substitute the `{{version}}` placeholder with the version from the Git tag during the release process. This ensures that the published packages have the correct version without manual intervention.

- Modified `package.json` and `pyproject.toml` to use `{{version}}`.
- Updated `.github/workflows/npm-publish.yml` to replace the version placeholder before publishing to npm.
- Updated `.github/workflows/publish.yml` to replace the version placeholder before publishing to PyPI.
- Added `build/` and `uv.lock` to `.gitignore` to avoid committing build artifacts.