### PR TITLE
fix: Correct Python publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: Upload Python Package
 
 on:
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+  release:
+    types: [published]
 
 jobs:
   build-and-publish:
@@ -18,14 +17,16 @@ jobs:
 
       - name: Update version in pyproject.toml
         run: |
-          VERSION=$(echo "${{ github.ref_name }}" | sed 's/^v//')
+          VERSION=$(echo "${{ github.event.release.tag_name }}" | sed 's/^v//')
           sed -i "s/version = \"{{version}}\"/version = \"$VERSION\"/g" pyproject.toml
 
-      - name: Set up Python and uv
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: "uv"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v1
 
       - name: Create virtual environment
         run: uv venv


### PR DESCRIPTION
This commit fixes two issues with the PyPI publishing workflow:

1.  The workflow was not being triggered on new releases. The trigger has been changed from `on: push: tags:` to `on: release: types: [published]` to align with the npm publishing workflow.
2.  The workflow was failing with a `uv` caching error. This has been resolved by using the `astral-sh/setup-uv@v1` action to handle `uv` setup and caching, instead of the `cache: "uv"` option in `actions/setup-python`.

The version replacement logic has also been updated to use `github.event.release.tag_name` to be compatible with the new release trigger.