### PR TITLE
fix: Exclude build directory from mypy check in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
         run: uv run ruff check .
 
       - name: Run mypy
-        run: uv run mypy .
+        run: uv run mypy . --exclude build
 
       - name: Build package
         run: uv run python -m build


### PR DESCRIPTION
This commit updates the PyPI publishing workflow to exclude the 'build' directory from the mypy check. This prevents a "Duplicate module" error that was causing the workflow to fail.