### PR TITLE
Fix all mypy errors by adding type annotations and stubs.

### DIFF
--- a/__tests__/test_helpers.py
+++ b/__tests__/test_helpers.py
@@ -1,16 +1,16 @@
 from worldalphabets import get_index_data, get_language
 
-def test_get_index_data():
+def test_get_index_data() -> None:
     data = get_index_data()
     assert isinstance(data, list)
     assert len(data) > 0
 
-def test_get_language():
+def test_get_language() -> None:
     lang_info = get_language('en')
     assert isinstance(lang_info, dict)
     assert lang_info['language'] == 'en'
     assert lang_info['language-name'] == 'English'
 
-def test_get_language_invalid():
+def test_get_language_invalid() -> None:
     lang_info = get_language('invalid-code')
     assert lang_info is None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dev = [
     "build>=0.10.0",
     "requests>=2.31.0",
     "beautifulsoup4>=4.12.3",
+    "types-requests",
+    "types-beautifulsoup4",
 ]
 
 [build-system]
@@ -38,3 +40,7 @@ python_version = "3.11"
 warn_unused_configs = true
 disallow_untyped_defs = true
 strict_optional = true
+
+[[tool.mypy.overrides]]
+module = "langcodes"
+ignore_missing_imports = true

--- a/scripts/create_index.py
+++ b/scripts/create_index.py
@@ -1,7 +1,7 @@
 import os
 import json
 import requests
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 import langcodes
 
 # Define paths
@@ -13,7 +13,7 @@ TABLE_FILE = "table.md"
 WRITING_SYSTEMS_URL = "https://en.wikipedia.org/wiki/List_of_writing_systems"
 ISO_639_1_URL = "https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes"
 
-def get_language_info():
+def get_language_info() -> dict[str, str]:
     """
     Scrapes Wikipedia to get language information.
     Returns a dictionary mapping language codes to their names.
@@ -21,10 +21,13 @@ def get_language_info():
     response = requests.get(ISO_639_1_URL)
     soup = BeautifulSoup(response.content, "html.parser")
 
-    try:
-        table = soup.find("table", {"class": "wikitable"}).find("tbody")
-    except AttributeError:
+    table_tag = soup.find("table", {"class": "wikitable"})
+    if not isinstance(table_tag, Tag):
         raise ValueError("Could not find the language table on the Wikipedia page.")
+
+    table = table_tag.find("tbody")
+    if not isinstance(table, Tag):
+        raise ValueError("Could not find the language table body on the Wikipedia page.")
 
     lang_code_to_name = {}
 
@@ -46,7 +49,7 @@ def get_language_info():
 
     return lang_code_to_name
 
-def get_direction_for_script(script_name):
+def get_direction_for_script(script_name: str) -> str:
     """
     Returns the writing direction for a given script.
     """
@@ -55,7 +58,7 @@ def get_direction_for_script(script_name):
         return "rl"
     return "lr"
 
-def get_script_info():
+def get_script_info() -> dict[str, dict[str, str]]:
     """
     Scrapes Wikipedia to get script information.
     Returns a dictionary mapping language names to their script and direction.
@@ -115,7 +118,7 @@ MANUAL_LANG_MAP = {
     "tl": "Tagalog",
 }
 
-def create_index():
+def create_index() -> None:
     """
     Generates the index.json file.
     """

--- a/scripts/generate_table.py
+++ b/scripts/generate_table.py
@@ -3,7 +3,7 @@ import json
 INDEX_FILE = "data/index.json"
 TABLE_FILE = "table.md"
 
-def generate_table():
+def generate_table() -> None:
     """
     Generates a Markdown table from the index.json file.
     """

--- a/src/worldalphabets/data/index.json
+++ b/src/worldalphabets/data/index.json
@@ -1,0 +1,947 @@
+[
+  {
+    "language": "af",
+    "language-name": "Afrikaans",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "ak",
+    "language-name": "Akan",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "am",
+    "language-name": "Amharic",
+    "frequency-avail": true,
+    "script-type": "Abugida",
+    "direction": "lr"
+  },
+  {
+    "language": "ar",
+    "language-name": "Arabic",
+    "frequency-avail": false,
+    "script-type": "AbjadorAbugida",
+    "direction": "rl"
+  },
+  {
+    "language": "ast",
+    "language-name": "Asturian",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "az",
+    "language-name": "Azerbaijani",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "ba",
+    "language-name": "Bashkir",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "ban",
+    "language-name": "Balinese",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "bax",
+    "language-name": "Bamun",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "be",
+    "language-name": "Belarusian",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "bg",
+    "language-name": "Bulgarian",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "bku",
+    "language-name": "Buhid",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "bm",
+    "language-name": "Bambara",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "bn",
+    "language-name": "Bengali",
+    "frequency-avail": true,
+    "script-type": "Abugida",
+    "direction": "lr"
+  },
+  {
+    "language": "bo",
+    "language-name": "Tibetan",
+    "frequency-avail": true,
+    "script-type": "Abugida",
+    "direction": "lr"
+  },
+  {
+    "language": "bug",
+    "language-name": "Buginese",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "bya",
+    "language-name": "Batak",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "ca",
+    "language-name": "Catalan",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "ceb",
+    "language-name": "Cebuano",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "chr",
+    "language-name": "Cherokee",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "ckb",
+    "language-name": "Central Kurdish",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "cop",
+    "language-name": "Coptic",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "cs",
+    "language-name": "Czech",
+    "frequency-avail": false,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "cv",
+    "language-name": "Chuvash",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "da",
+    "language-name": "Danish",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "de",
+    "language-name": "German",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "dz",
+    "language-name": "Dzongkha",
+    "frequency-avail": true,
+    "script-type": "Abugida",
+    "direction": "lr"
+  },
+  {
+    "language": "el",
+    "language-name": "Greek",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "en",
+    "language-name": "English",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "eo",
+    "language-name": "Esperanto",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "es",
+    "language-name": "Spanish",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "et",
+    "language-name": "Estonian",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "eu",
+    "language-name": "Basque",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "fa",
+    "language-name": "Persian",
+    "frequency-avail": true,
+    "script-type": "AbjadorAbugida",
+    "direction": "rl"
+  },
+  {
+    "language": "fi",
+    "language-name": "Finnish",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "fo",
+    "language-name": "Faroese",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "fr",
+    "language-name": "French",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "fur",
+    "language-name": "Friulian",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "ga",
+    "language-name": "Irish",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "gd",
+    "language-name": "Scottish Gaelic",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "gez",
+    "language-name": "Geez",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "gl",
+    "language-name": "Galician",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "gu",
+    "language-name": "Gujarati",
+    "frequency-avail": true,
+    "script-type": "Abugida",
+    "direction": "lr"
+  },
+  {
+    "language": "gv",
+    "language-name": "Manx",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "haw",
+    "language-name": "Hawaiian",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "he",
+    "language-name": "Hebrew",
+    "frequency-avail": true,
+    "script-type": "Abjad",
+    "direction": "rl"
+  },
+  {
+    "language": "hi",
+    "language-name": "Hindi",
+    "frequency-avail": true,
+    "script-type": "Abugida",
+    "direction": "lr"
+  },
+  {
+    "language": "hnn",
+    "language-name": "Hanunoo",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "ht",
+    "language-name": "Haitian Creole",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "hu",
+    "language-name": "Hungarian",
+    "frequency-avail": false,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "hy",
+    "language-name": "Armenian",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "ie",
+    "language-name": "Interlingue",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "is",
+    "language-name": "Icelandic",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "it",
+    "language-name": "Italian",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "ja",
+    "language-name": "Japanese",
+    "frequency-avail": true,
+    "script-type": "Logographic",
+    "direction": "lr"
+  },
+  {
+    "language": "jv",
+    "language-name": "Javanese",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "ka",
+    "language-name": "Georgian",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "kab",
+    "language-name": "Kabyle",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "kk",
+    "language-name": "Kazakh",
+    "frequency-avail": true,
+    "script-type": "AbjadorAbugida",
+    "direction": "rl"
+  },
+  {
+    "language": "kl",
+    "language-name": "Kalaallisut",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "km",
+    "language-name": "Khmer",
+    "frequency-avail": true,
+    "script-type": "Abugida",
+    "direction": "lr"
+  },
+  {
+    "language": "kn",
+    "language-name": "Kannada",
+    "frequency-avail": true,
+    "script-type": "Abugida",
+    "direction": "lr"
+  },
+  {
+    "language": "ko",
+    "language-name": "Korean",
+    "frequency-avail": true,
+    "script-type": "Logographic",
+    "direction": "lr"
+  },
+  {
+    "language": "ks",
+    "language-name": "Kashmiri",
+    "frequency-avail": true,
+    "script-type": "AbjadorAbugida",
+    "direction": "rl"
+  },
+  {
+    "language": "ksh",
+    "language-name": "Colognian",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "ku",
+    "language-name": "Kurdish",
+    "frequency-avail": true,
+    "script-type": "AbjadorAbugida",
+    "direction": "rl"
+  },
+  {
+    "language": "ky",
+    "language-name": "Kyrgyz",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "la",
+    "language-name": "Latin",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "lb",
+    "language-name": "Luxembourgish",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "lep",
+    "language-name": "Lepcha",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "lif",
+    "language-name": "Limbu",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "lij",
+    "language-name": "Ligurian",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "lis",
+    "language-name": "Lisu",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "lo",
+    "language-name": "Lao",
+    "frequency-avail": true,
+    "script-type": "Abugida",
+    "direction": "lr"
+  },
+  {
+    "language": "lt",
+    "language-name": "Lithuanian",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "lv",
+    "language-name": "Latvian",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "mg",
+    "language-name": "Malagasy",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "mid",
+    "language-name": "Mandaic",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "mk",
+    "language-name": "Macedonian",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "ml",
+    "language-name": "Malayalam",
+    "frequency-avail": true,
+    "script-type": "Abugida",
+    "direction": "lr"
+  },
+  {
+    "language": "mn",
+    "language-name": "Mongolian",
+    "frequency-avail": false,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "mo",
+    "language-name": "Romanian",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "my",
+    "language-name": "Burmese",
+    "frequency-avail": true,
+    "script-type": "Abugida",
+    "direction": "lr"
+  },
+  {
+    "language": "mzn",
+    "language-name": "Mazanderani",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "nds",
+    "language-name": "Low German",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "ne",
+    "language-name": "Nepali",
+    "frequency-avail": true,
+    "script-type": "Abugida",
+    "direction": "lr"
+  },
+  {
+    "language": "nn",
+    "language-name": "Norwegian Nynorsk",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "no",
+    "language-name": "Norwegian",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "nqo",
+    "language-name": "N’Ko",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "nso",
+    "language-name": "Northern Sotho",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "oc",
+    "language-name": "Occitan",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "or",
+    "language-name": "Odia",
+    "frequency-avail": true,
+    "script-type": "Abugida",
+    "direction": "lr"
+  },
+  {
+    "language": "pl",
+    "language-name": "Polish",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "ps",
+    "language-name": "Pashto",
+    "frequency-avail": true,
+    "script-type": "AbjadorAbugida",
+    "direction": "rl"
+  },
+  {
+    "language": "pt",
+    "language-name": "Portuguese",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "rej",
+    "language-name": "Rejang",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "rm",
+    "language-name": "Romansh",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "ro",
+    "language-name": "Romanian",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "ru",
+    "language-name": "Russian",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "sa",
+    "language-name": "Sanskrit",
+    "frequency-avail": true,
+    "script-type": "Abugida",
+    "direction": "lr"
+  },
+  {
+    "language": "sam",
+    "language-name": "Samaritan Aramaic",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "saz",
+    "language-name": "Saurashtra",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "sc",
+    "language-name": "Sardinian",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "se",
+    "language-name": "Northern Sami",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "sg",
+    "language-name": "Sango",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "si",
+    "language-name": "Sinhala",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "sl",
+    "language-name": "Slovenian",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "sn",
+    "language-name": "Shona",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "so",
+    "language-name": "Somali",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "sr",
+    "language-name": "Serbian",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "su",
+    "language-name": "Sundanese",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "sv",
+    "language-name": "Swedish",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "syr",
+    "language-name": "Syriac",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "szl",
+    "language-name": "Silesian",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "ta",
+    "language-name": "Tamil",
+    "frequency-avail": true,
+    "script-type": "Abugida",
+    "direction": "lr"
+  },
+  {
+    "language": "tbw",
+    "language-name": "Tagbanwa",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "te",
+    "language-name": "Telugu",
+    "frequency-avail": true,
+    "script-type": "Abugida",
+    "direction": "lr"
+  },
+  {
+    "language": "tg",
+    "language-name": "Tajik",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "th",
+    "language-name": "Thai",
+    "frequency-avail": true,
+    "script-type": "Abugida",
+    "direction": "lr"
+  },
+  {
+    "language": "ti",
+    "language-name": "Tigrinya",
+    "frequency-avail": true,
+    "script-type": "Abugida",
+    "direction": "lr"
+  },
+  {
+    "language": "tk",
+    "language-name": "Turkmen",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "tl",
+    "language-name": "Tagalog",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "tn",
+    "language-name": "Tswana",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "tr",
+    "language-name": "Turkish",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "tt",
+    "language-name": "Tatar",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "uk",
+    "language-name": "Ukrainian",
+    "frequency-avail": true,
+    "script-type": "Alphabet",
+    "direction": "lr"
+  },
+  {
+    "language": "ur",
+    "language-name": "Urdu",
+    "frequency-avail": true,
+    "script-type": "AbjadorAbugida",
+    "direction": "rl"
+  },
+  {
+    "language": "vai",
+    "language-name": "Vai",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "vec",
+    "language-name": "Venetian",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "wo",
+    "language-name": "Wolof",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "zh-classical",
+    "language-name": "zh-classical",
+    "frequency-avail": true,
+    "script-type": "TBD",
+    "direction": "TBD"
+  },
+  {
+    "language": "zh-min-nan",
+    "language-name": "Min",
+    "frequency-avail": true,
+    "script-type": "Logographic",
+    "direction": "lr"
+  },
+  {
+    "language": "zh-yue",
+    "language-name": "Yue",
+    "frequency-avail": true,
+    "script-type": "Logographic",
+    "direction": "lr"
+  },
+  {
+    "language": "zh",
+    "language-name": "Mandarin",
+    "frequency-avail": true,
+    "script-type": "Logographic",
+    "direction": "lr"
+  },
+  {
+    "language": "zra",
+    "language-name": "Kara (Korea)",
+    "frequency-avail": false,
+    "script-type": "TBD",
+    "direction": "TBD"
+  }
+]

--- a/src/worldalphabets/helpers.py
+++ b/src/worldalphabets/helpers.py
@@ -5,7 +5,7 @@ INDEX_FILE = files("worldalphabets") / "data" / "index.json"
 
 _index_data = None
 
-def get_index_data():
+def get_index_data() -> list[dict]:
     """
     Loads the index.json data.
     """
@@ -14,7 +14,8 @@ def get_index_data():
         _index_data = json.loads(INDEX_FILE.read_text(encoding="utf-8"))
     return _index_data
 
-def get_language(lang_code):
+
+def get_language(lang_code: str) -> dict | None:
     """
     Returns information for a specific language.
     """


### PR DESCRIPTION
This change addresses all mypy errors reported in the linting job.
- Adds type hints to function definitions in all Python files that had errors.
- Updates pyproject.toml to include dev dependencies for `types-requests` and `types-beautifulsoup4`.
- Configures mypy in pyproject.toml to ignore missing imports for `langcodes`, which does not have type stubs.
- Adds the generated `src/worldalphabets/data/index.json` file. This file was missing, causing tests to fail. The project's .gitignore indicates that data files are intended to be kept in the repository.
- Fixes a bug in `scripts/create_index.py` where a `None` value could be accessed, which was caught by mypy after adding type stubs.