### PR TITLE
Add Python example for Markdown keyboard layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,15 +119,23 @@ Key entries expose `pos` (a [`KeyboardEvent.code`](https://developer.mozilla.org
 
 #### Python
 
+A helper in `examples/keyboard_md_table.py` renders a layout as a Markdown
+table:
+
 ```python
-from worldalphabets.keyboards import get_available_layouts, load_keyboard
+from examples.keyboard_md_table import layout_to_markdown
 
-layouts = get_available_layouts()
-print("Available layouts (first 5):", layouts[:5])
+print(layout_to_markdown("en-united-kingdom"))
+```
 
-kb = load_keyboard("en-us")
-print("First key Unicode:", kb.keys[1].get_unicode("base"))
-print("First key position:", kb.keys[1].pos, kb.keys[1].row, kb.keys[1].col)
+Output:
+
+```
+| ` | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 0 | - | = |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| q | w | e | r | t | y | u | i | o | p | [ | ] |
+| a | s | d | f | g | h | j | k | l | ; | ' | # |
+| z | x | c | v | b | n | m | , | . | / |
 ```
 
 #### Node.js

--- a/examples/keyboard_md_table.py
+++ b/examples/keyboard_md_table.py
@@ -1,0 +1,85 @@
+"""Print the base layer of a keyboard layout as a Markdown table."""
+from worldalphabets import load_keyboard
+
+LAYOUT_ROWS = [
+    [
+        "Backquote",
+        "Digit1",
+        "Digit2",
+        "Digit3",
+        "Digit4",
+        "Digit5",
+        "Digit6",
+        "Digit7",
+        "Digit8",
+        "Digit9",
+        "Digit0",
+        "Minus",
+        "Equal",
+    ],
+    [
+        "KeyQ",
+        "KeyW",
+        "KeyE",
+        "KeyR",
+        "KeyT",
+        "KeyY",
+        "KeyU",
+        "KeyI",
+        "KeyO",
+        "KeyP",
+        "BracketLeft",
+        "BracketRight",
+    ],
+    [
+        "KeyA",
+        "KeyS",
+        "KeyD",
+        "KeyF",
+        "KeyG",
+        "KeyH",
+        "KeyJ",
+        "KeyK",
+        "KeyL",
+        "Semicolon",
+        "Quote",
+        "Backslash",
+    ],
+    [
+        "KeyZ",
+        "KeyX",
+        "KeyC",
+        "KeyV",
+        "KeyB",
+        "KeyN",
+        "KeyM",
+        "Comma",
+        "Period",
+        "Slash",
+    ],
+]
+
+def layout_to_markdown(layout_id: str, layer: str = "base") -> str:
+    """Return the layout's ``layer`` as a Markdown table."""
+    layout = load_keyboard(layout_id)
+    key_by_pos = {k.pos: k for k in layout.keys}
+
+    def legend(pos: str) -> str:
+        key = key_by_pos.get(pos)
+        if not key:
+            return ""
+        value = getattr(key.legends, layer)
+        return value or ""
+
+    header = [legend(p) for p in LAYOUT_ROWS[0]]
+    lines = [
+        "| " + " | ".join(header) + " |",
+        "|" + " --- |" * len(header),
+    ]
+    for row in LAYOUT_ROWS[1:]:
+        line = [legend(p) for p in row]
+        lines.append("| " + " | ".join(line) + " |")
+    return "\n".join(lines)
+
+if __name__ == "__main__":
+    print(layout_to_markdown("en-united-kingdom"))


### PR DESCRIPTION
## Summary
- add `layout_to_markdown` helper and example script for keyboard layouts
- document script usage in README with UK layout demonstration

## Testing
- `uv run examples/keyboard_md_table.py`
- `uv run ruff check examples`
- `uv run mypy --ignore-missing-imports examples/keyboard_md_table.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8e4b949ac8327a4ad7f593df24be3