### PR TITLE
fix: set pyproject version from release tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Update version in pyproject.toml
+      - name: Set version from release tag
         run: |
           VERSION=$(echo "${{ github.event.release.tag_name }}" | sed 's/^v//')
-          sed -i "s/version = \"{{version}}\"/version = \"$VERSION\"/g" pyproject.toml
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" pyproject.toml
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- update release workflow to sync pyproject version with release tag

## Testing
- `uv run ruff check .`
- `uv run mypy . --exclude build`


------
https://chatgpt.com/codex/tasks/task_e_68a8e89dcb5c83279cd5679450cbaa11