### PR TITLE
Clarify installation and remove unused dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ A tool to access alphabets of the world with Python and Node interfaces.
 
 ### Python
 
+Install the package:
+
+```bash
+pip install worldalphabets
+```
+
 To load the data in Python:
 
 ```python
@@ -127,11 +133,12 @@ Key entries expose `pos` (a [`KeyboardEvent.code`](https://developer.mozilla.org
 
 #### Python
 
-A helper in `examples/keyboard_md_table.py` renders a layout as a Markdown
-table:
+The script `examples/python/keyboard_md_table.py` demonstrates rendering a
+layout as a Markdown table. Copy the `layout_to_markdown` helper into your
+project and use it like this:
 
 ```python
-from examples.keyboard_md_table import layout_to_markdown
+from keyboard_md_table import layout_to_markdown
 
 print(layout_to_markdown("en-united-kingdom"))
 ```
@@ -144,6 +151,7 @@ Output:
 | q | w | e | r | t | y | u | i | o | p | [ | ] |
 | a | s | d | f | g | h | j | k | l | ; | ' | # |
 | z | x | c | v | b | n | m | , | . | / |
+| ␠ |
 
 #### Node.js
 

--- a/examples/python/keyboard_md_table.py
+++ b/examples/python/keyboard_md_table.py
@@ -57,6 +57,7 @@ LAYOUT_ROWS = [
         "Period",
         "Slash",
     ],
+    ["Space"],
 ]
 
 def layout_to_markdown(layout_id: str, layer: str = "base") -> str:
@@ -69,6 +70,8 @@ def layout_to_markdown(layout_id: str, layer: str = "base") -> str:
         if not key:
             return ""
         value = getattr(key.legends, layer)
+        if value == " ":
+            return "␠"
         return value or ""
 
     header = [legend(p) for p in LAYOUT_ROWS[0]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 
 dependencies = [
-    "langcodes>=3.3.0",
-    "language-data>=1.1.0",
     "pydantic>=2.0.0",
-    "lxml>=4.9.0",
 ]
 
 [project.optional-dependencies]
@@ -16,10 +13,12 @@ dev = [
     "pytest>=8.0.0",
     "ruff>=0.1.0",
     "mypy>=1.0.0",
+    "lxml>=4.9.0",
     "lxml-stubs>=0.5.0",
     "build>=0.10.0",
     "requests>=2.31.0",
     "beautifulsoup4>=4.12.3",
+    "langcodes>=3.3.0",
     "types-requests",
     "types-beautifulsoup4",
 ]


### PR DESCRIPTION
## Summary
- document `pip install worldalphabets` and clarify keyboard example usage
- show space key in keyboard markdown helper
- drop unused runtime dependencies, keeping only pydantic

## Testing
- `uv run ruff check examples/python/keyboard_md_table.py`
- `MYPYPATH=src uv run mypy examples/python/keyboard_md_table.py`
- `uv run pytest tests/test_keyboards.py`


------
https://chatgpt.com/codex/tasks/task_e_68a95a83831c832784642684aa6da56e