### PR TITLE
feat: dynamic audio player and keyboard tab

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,47 @@
+name: Deploy Web
+
+on:
+  push:
+    branches: ['main']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+      - name: Install dependencies
+        working-directory: web
+        run: npm ci
+      - name: Build site
+        working-directory: web
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: web/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ The `examples/` directory contains small scripts demonstrating the library:
   stats, and more.
 - `examples/node/` includes similar examples for Node.js.
 
+### Audio Samples
+
+Audio recordings are stored under `data/audio/` and named
+`{langcode}_{engine}_{voiceid}.wav`. Available voices are listed in
+`data/audio/index.json`.
+
+### Web Interface
+
+The Vue app under `web/` compiles to a static site with `npm run build`.
+GitHub Pages publishes the contents of `web/dist` through a workflow that
+runs on every push to `main`.
+
 ### Alphabet Index
 
 This library also provides an index of all available alphabets with additional metadata.

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "npm-run-all predev vite-dev",
     "vite-dev": "vite",
-    "predev": "cpr ../data ./public/data -o && ([ -d ../audio ] && cpr ../audio ./public/audio -o || true)",
+    "predev": "cpr ../data ./public/data -o",
     "build": "npm run predev && vite build",
     "preview": "vite preview"
   },

--- a/web/src/components/KeyboardView.vue
+++ b/web/src/components/KeyboardView.vue
@@ -1,27 +1,110 @@
 <script setup>
-defineProps({
-  layoutData: Object
+import { computed } from 'vue';
+
+const props = defineProps({
+  layoutData: Object,
 });
+
+const LAYOUT_ROWS = [
+  [
+    'Backquote',
+    'Digit1',
+    'Digit2',
+    'Digit3',
+    'Digit4',
+    'Digit5',
+    'Digit6',
+    'Digit7',
+    'Digit8',
+    'Digit9',
+    'Digit0',
+    'Minus',
+    'Equal',
+  ],
+  [
+    'KeyQ',
+    'KeyW',
+    'KeyE',
+    'KeyR',
+    'KeyT',
+    'KeyY',
+    'KeyU',
+    'KeyI',
+    'KeyO',
+    'KeyP',
+    'BracketLeft',
+    'BracketRight',
+  ],
+  [
+    'KeyA',
+    'KeyS',
+    'KeyD',
+    'KeyF',
+    'KeyG',
+    'KeyH',
+    'KeyJ',
+    'KeyK',
+    'KeyL',
+    'Semicolon',
+    'Quote',
+    'Backslash',
+  ],
+  [
+    'KeyZ',
+    'KeyX',
+    'KeyC',
+    'KeyV',
+    'KeyB',
+    'KeyN',
+    'KeyM',
+    'Comma',
+    'Period',
+    'Slash',
+  ],
+  ['Space'],
+];
+
+const ROW_OFFSETS = [0, 1, 1, 2, 5];
+
+const rows = computed(() => {
+  const data = props.layoutData;
+  if (!data || !Array.isArray(data.keys)) {
+    return [];
+  }
+  const keyByPos = {};
+  for (const k of data.keys) {
+    keyByPos[k.pos] = k;
+  }
+  return LAYOUT_ROWS.map((row, idx) => {
+    const off = ROW_OFFSETS[idx];
+    const cells = Array(off).fill('');
+    for (const pos of row) {
+      const key = keyByPos[pos];
+      let val = '';
+      if (key && key.legends && key.legends.base) {
+        val = key.legends.base === ' ' ? '␠' : key.legends.base;
+      }
+      cells.push(val || '');
+    }
+    return cells;
+  });
+});
+
+function hasRows() {
+  return rows.value.length > 0;
+}
 </script>
 
 <template>
   <div>
     <h3>Keyboard Layout</h3>
-    <div v-if="layoutData" class="keyboard-container">
-      <div
-        v-for="key in layoutData.keys"
-        :key="key.sc"
-        class="key"
-        :style="{
-          left: `${key.shape.x * 20}px`,
-          top: `${key.shape.y * 20}px`,
-          width: `${key.shape.w * 20}px`,
-          height: `${key.shape.h * 20}px`,
-        }"
-      >
-        {{ key.legends.base || '' }}
-      </div>
-    </div>
+    <table v-if="hasRows()" class="keyboard-table">
+      <tbody>
+        <tr v-for="(row, rIdx) in rows" :key="rIdx">
+          <td v-for="(cell, cIdx) in row" :key="cIdx">{{ cell }}</td>
+        </tr>
+      </tbody>
+    </table>
     <div v-else>
       <p>No keyboard layout available for this language.</p>
     </div>
@@ -29,25 +112,16 @@ defineProps({
 </template>
 
 <style scoped>
-.keyboard-container {
-  position: relative;
-  min-height: 200px; /* Adjust as needed */
+.keyboard-table {
+  border-collapse: collapse;
   margin-top: 1em;
-  border: 1px solid #ccc;
-  padding: 1em;
-  border-radius: 4px;
-  overflow: auto;
 }
 
-.key {
-  position: absolute;
-  border: 1px solid #999;
-  border-radius: 4px;
-  background-color: #f9f9f9;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-size: 0.8em;
-  box-sizing: border-box;
+.keyboard-table td {
+  border: 1px solid #ccc;
+  padding: 4px;
+  min-width: 20px;
+  text-align: center;
 }
 </style>
+


### PR DESCRIPTION
## Summary
- fetch audio options from `data/audio/index.json` and expose dropdown player
- show keyboard layout in a dedicated tab using table rendering
- streamline web predev script and document audio samples
- build the Vue web app and deploy its `dist` directory to GitHub Pages

## Testing
- `uv run ruff check .`
- `uv run mypy --install-types --non-interactive .`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab50e7067483279b29bd8f1d1fb5d2