### PR TITLE
feat: dynamic audio player, keyboard tab, and language routes

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,47 @@
+name: Deploy Web
+
+on:
+  push:
+    branches: ['main']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+      - name: Install dependencies
+        working-directory: web
+        run: npm ci
+      - name: Build site
+        working-directory: web
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: web/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ src/worldalphabets.egg-info/
 
 # Node
 node_modules/
+
+# Web app generated assets
+web/public/data/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,9 +3,11 @@
 - This repository mixes Python and Node code. Development code to build the data stores are in pytthon, while the published library is in Node and Python. 
 - Use uv from astral.sh for running scripts and checks.
 - Use `uv run` for Python scripts and checks.
-- Run `ruff check` and `mypy` on any Python files you modify.
+- Run `ruff check` and `mypy` on any Python files you modify. (NB: uv run mypy --install-types for types installation)
 - Run `npm test` when JavaScript files are changed.
 - Keep lines under 88 characters when possible.
 - Store generated alphabet JSON under `data/alphabets/`.
+- Note scripts are in `scripts/`. Many of these are used to generate data files. 
 - Document significant script or data changes in `README.md`.
+- A webUI which is built using vue+vite is in the `webui/` directory. Note its a static site with no backend. Hosted on github pages. (See workflows)
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ Audio recordings are stored under `data/audio/` and named
 ### Web Interface
 
 The Vue app under `web/` compiles to a static site with `npm run build`.
+To work on the interface locally, install its dependencies and start the
+development server:
+
+```bash
+cd web
+npm install
+npm run dev
+```
 GitHub Pages publishes the contents of `web/dist` through a workflow that
 runs on every push to `main`.
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ The `examples/` directory contains small scripts demonstrating the library:
   stats, and more.
 - `examples/node/` includes similar examples for Node.js.
 
+### Audio Samples
+
+Audio recordings are stored under `data/audio/` and named
+`{langcode}_{engine}_{voiceid}.wav`. Available voices are listed in
+`data/audio/index.json`.
+
+### Web Interface
+
+The Vue app under `web/` compiles to a static site with `npm run build`.
+GitHub Pages publishes the contents of `web/dist` through a workflow that
+runs on every push to `main`.
+
+Each language view is addressable at `/<code>`, allowing pages to be
+bookmarked directly.
+
 ### Alphabet Index
 
 This library also provides an index of all available alphabets with additional metadata.

--- a/data/layouts/index.json
+++ b/data/layouts/index.json
@@ -1,0 +1,253 @@
+{
+  "ar": [
+    "ar-arabic-101",
+    "ar-arabic-102-azerty",
+    "ar-arabic-102"
+  ],
+  "az": [
+    "az-azerbaijani-latin",
+    "az-azerbaijani-standard"
+  ],
+  "ba": [
+    "ba-bashkir"
+  ],
+  "be": [
+    "be-belarusian"
+  ],
+  "bg": [
+    "bg-bulgarian-latin",
+    "bg-bulgarian-phonetic-traditional",
+    "bg-bulgarian-phonetic",
+    "bg-bulgarian-typewriter",
+    "bg-bulgarian"
+  ],
+  "bn": [
+    "bn-bangla"
+  ],
+  "bo": [
+    "bo-tibetan-prc---updated",
+    "bo-tibetan-prc"
+  ],
+  "bug": [
+    "bug-buginese"
+  ],
+  "ckb": [
+    "ckb-central-kurdish"
+  ],
+  "cs": [
+    "cs-czech-qwerty",
+    "cs-czech"
+  ],
+  "da": [
+    "da-danish"
+  ],
+  "de": [
+    "de-DE-qwertz",
+    "de-german-ibm",
+    "de-german",
+    "de-swiss-german"
+  ],
+  "dz": [
+    "dz-dzongkha"
+  ],
+  "el": [
+    "el-greek-220-latin",
+    "el-greek-220",
+    "el-greek-319-latin",
+    "el-greek-319",
+    "el-greek-latin",
+    "el-greek"
+  ],
+  "en": [
+    "en-GB-qwerty",
+    "en-english-india",
+    "en-united-kingdom",
+    "en-united-states-dvorak",
+    "en-united-states-international",
+    "en-us"
+  ],
+  "es": [
+    "es-latin-american",
+    "es-spanish"
+  ],
+  "et": [
+    "et-estonian"
+  ],
+  "fa": [
+    "fa-persian-standard",
+    "fa-persian"
+  ],
+  "fi": [
+    "fi-finnish-with-sami",
+    "fi-finnish"
+  ],
+  "fo": [
+    "fo-faeroese"
+  ],
+  "fr": [
+    "fr-belgian-french",
+    "fr-canadian-french-legacy",
+    "fr-canadian-french",
+    "fr-french-legacy-azerty",
+    "fr-french-standard-azerty",
+    "fr-french-standard-bpo",
+    "fr-swiss-french"
+  ],
+  "ga": [
+    "ga-irish"
+  ],
+  "gd": [
+    "gd-scottish-gaelic"
+  ],
+  "gu": [
+    "gu-gujarati"
+  ],
+  "haw": [
+    "haw-hawaiian"
+  ],
+  "he": [
+    "he-hebrew-standard-2018",
+    "he-hebrew-standard",
+    "he-hebrew"
+  ],
+  "hu": [
+    "hu-hungarian"
+  ],
+  "is": [
+    "is-icelandic"
+  ],
+  "it": [
+    "it-italian-142",
+    "it-italian"
+  ],
+  "ja": [
+    "ja-japanese"
+  ],
+  "jv": [
+    "jv-javanese"
+  ],
+  "ka": [
+    "ka-georgian-ergonomic",
+    "ka-georgian-legacy",
+    "ka-georgian-mes",
+    "ka-georgian-old-alphabets",
+    "ka-georgian-qwerty"
+  ],
+  "kk": [
+    "kk-kazakh"
+  ],
+  "km": [
+    "km-khmer-nida",
+    "km-khmer"
+  ],
+  "kn": [
+    "kn-kannada"
+  ],
+  "ko": [
+    "ko-korean"
+  ],
+  "lb": [
+    "lb-luxembourgish"
+  ],
+  "lis": [
+    "lis-lisu-basic",
+    "lis-lisu-standard"
+  ],
+  "lo": [
+    "lo-lao"
+  ],
+  "lt": [
+    "lt-lithuanian"
+  ],
+  "lv": [
+    "lv-latvian-qwerty",
+    "lv-latvian-standard",
+    "lv-latvian"
+  ],
+  "mk": [
+    "mk-macedonian"
+  ],
+  "ml": [
+    "ml-malayalam"
+  ],
+  "mn": [
+    "mn-mongolian-mongolian-script"
+  ],
+  "ne": [
+    "ne-nepali"
+  ],
+  "no": [
+    "no-norwegian-with-sami",
+    "no-norwegian"
+  ],
+  "nqo": [
+    "nqo-nko"
+  ],
+  "or": [
+    "or-odia"
+  ],
+  "pl": [
+    "pl-polish-214",
+    "pl-polish-programmers"
+  ],
+  "ps": [
+    "ps-pashto-afghanistan"
+  ],
+  "pt": [
+    "pt-portuguese-brazil-abnt",
+    "pt-portuguese-brazil-abnt2",
+    "pt-portuguese"
+  ],
+  "ro": [
+    "ro-romanian-legacy",
+    "ro-romanian-programmers",
+    "ro-romanian-standard"
+  ],
+  "ru": [
+    "ru-russian-typewriter",
+    "ru-russian"
+  ],
+  "si": [
+    "si-sinhala"
+  ],
+  "sl": [
+    "sl-slovenian"
+  ],
+  "sr": [
+    "sr-serbian-cyrillic",
+    "sr-serbian-latin"
+  ],
+  "sv": [
+    "sv-swedish-with-sami",
+    "sv-swedish"
+  ],
+  "syr": [
+    "syr-syriac"
+  ],
+  "ta": [
+    "ta-tamil"
+  ],
+  "te": [
+    "te-telugu"
+  ],
+  "tg": [
+    "tg-tajik"
+  ],
+  "tk": [
+    "tk-turkmen"
+  ],
+  "tt": [
+    "tt-tatar-legacy",
+    "tt-tatar"
+  ],
+  "uk": [
+    "uk-ukrainian-enhanced",
+    "uk-ukrainian"
+  ],
+  "ur": [
+    "ur-urdu"
+  ],
+  "wo": [
+    "wo-wolof"
+  ]
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,7 +8,8 @@
       "name": "web",
       "version": "0.0.0",
       "dependencies": {
-        "vue": "^3.5.18"
+        "vue": "^3.5.18",
+        "vue-router": "^4.3.0"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.1",
@@ -820,6 +821,12 @@
         "@vue/compiler-dom": "3.5.19",
         "@vue/shared": "3.5.19"
       }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
     },
     "node_modules/@vue/reactivity": {
       "version": "3.5.19",
@@ -3186,6 +3193,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
       }
     },
     "node_modules/which": {

--- a/web/package.json
+++ b/web/package.json
@@ -6,12 +6,13 @@
   "scripts": {
     "dev": "npm-run-all predev vite-dev",
     "vite-dev": "vite",
-    "predev": "cpr ../data ./public/data -o && ([ -d ../audio ] && cpr ../audio ./public/audio -o || true)",
+    "predev": "cpr ../data ./public/data -o",
     "build": "npm run predev && vite build",
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.5.18"
+    "vue": "^3.5.18",
+    "vue-router": "^4.3.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.1",

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,26 +1,6 @@
 <script setup>
-import { ref } from 'vue';
-import LanguageList from './components/LanguageList.vue';
-import LanguageDetails from './components/LanguageDetails.vue';
-
-const selectedLangCode = ref(null);
-
-function handleLanguageSelected(langCode) {
-  selectedLangCode.value = langCode;
-}
 </script>
 
 <template>
-  <main class="app-container">
-    <LanguageList @language-selected="handleLanguageSelected" />
-    <LanguageDetails :selected-lang-code="selectedLangCode" />
-  </main>
+  <router-view />
 </template>
-
-<style scoped>
-.app-container {
-  display: grid;
-  grid-template-columns: 300px 1fr;
-  height: 100vh;
-}
-</style>

--- a/web/src/components/AlphabetView.vue
+++ b/web/src/components/AlphabetView.vue
@@ -66,7 +66,7 @@ function handleCopyLetter(letter) {
 <template>
   <div>
     <div class="header-container">
-      <h3>Alphabet</h3>
+      <h3>Letters</h3>
       <button @click="handleCopyAll" v-if="currentAlphabet.length > 0">{{ copyAllText }}</button>
     </div>
 

--- a/web/src/components/KeyboardView.vue
+++ b/web/src/components/KeyboardView.vue
@@ -131,5 +131,8 @@ function hasRows() {
 .keyboard-count {
   margin-top: 0.5em;
 }
+h3 {
+  margin-bottom: 0.5em;
+}
 </style>
 

--- a/web/src/components/KeyboardView.vue
+++ b/web/src/components/KeyboardView.vue
@@ -1,27 +1,114 @@
 <script setup>
-defineProps({
-  layoutData: Object
+import { computed } from 'vue';
+
+const props = defineProps({
+  layoutData: Object,
+  total: Number,
 });
+
+const LAYOUT_ROWS = [
+  [
+    'Backquote',
+    'Digit1',
+    'Digit2',
+    'Digit3',
+    'Digit4',
+    'Digit5',
+    'Digit6',
+    'Digit7',
+    'Digit8',
+    'Digit9',
+    'Digit0',
+    'Minus',
+    'Equal',
+  ],
+  [
+    'KeyQ',
+    'KeyW',
+    'KeyE',
+    'KeyR',
+    'KeyT',
+    'KeyY',
+    'KeyU',
+    'KeyI',
+    'KeyO',
+    'KeyP',
+    'BracketLeft',
+    'BracketRight',
+  ],
+  [
+    'KeyA',
+    'KeyS',
+    'KeyD',
+    'KeyF',
+    'KeyG',
+    'KeyH',
+    'KeyJ',
+    'KeyK',
+    'KeyL',
+    'Semicolon',
+    'Quote',
+    'Backslash',
+  ],
+  [
+    'KeyZ',
+    'KeyX',
+    'KeyC',
+    'KeyV',
+    'KeyB',
+    'KeyN',
+    'KeyM',
+    'Comma',
+    'Period',
+    'Slash',
+  ],
+  ['Space'],
+];
+
+const ROW_OFFSETS = [0, 1, 1, 2, 5];
+
+const rows = computed(() => {
+  const data = props.layoutData;
+  if (!data || !Array.isArray(data.keys)) {
+    return [];
+  }
+  const keyByPos = {};
+  for (const k of data.keys) {
+    keyByPos[k.pos] = k;
+  }
+  return LAYOUT_ROWS.map((row, idx) => {
+    const off = ROW_OFFSETS[idx];
+    const cells = Array(off).fill('');
+    for (const pos of row) {
+      const key = keyByPos[pos];
+      let val = '';
+      if (key && key.legends && key.legends.base) {
+        val = key.legends.base === ' ' ? '␠' : key.legends.base;
+      }
+      cells.push(val || '');
+    }
+    return cells;
+  });
+});
+
+function hasRows() {
+  return rows.value.length > 0;
+}
 </script>
 
 <template>
   <div>
     <h3>Keyboard Layout</h3>
-    <div v-if="layoutData" class="keyboard-container">
-      <div
-        v-for="key in layoutData.keys"
-        :key="key.sc"
-        class="key"
-        :style="{
-          left: `${key.shape.x * 20}px`,
-          top: `${key.shape.y * 20}px`,
-          width: `${key.shape.w * 20}px`,
-          height: `${key.shape.h * 20}px`,
-        }"
-      >
-        {{ key.legends.base || '' }}
-      </div>
-    </div>
+    <p class="keyboard-count" v-if="typeof total === 'number'">
+      Showing first of {{ total }} keyboard layout{{ total === 1 ? '' : 's' }}
+    </p>
+    <table v-if="hasRows()" class="keyboard-table">
+      <tbody>
+        <tr v-for="(row, rIdx) in rows" :key="rIdx">
+          <td v-for="(cell, cIdx) in row" :key="cIdx">{{ cell }}</td>
+        </tr>
+      </tbody>
+    </table>
     <div v-else>
       <p>No keyboard layout available for this language.</p>
     </div>
@@ -29,25 +116,20 @@ defineProps({
 </template>
 
 <style scoped>
-.keyboard-container {
-  position: relative;
-  min-height: 200px; /* Adjust as needed */
+.keyboard-table {
+  border-collapse: collapse;
   margin-top: 1em;
-  border: 1px solid #ccc;
-  padding: 1em;
-  border-radius: 4px;
-  overflow: auto;
 }
 
-.key {
-  position: absolute;
-  border: 1px solid #999;
-  border-radius: 4px;
-  background-color: #f9f9f9;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-size: 0.8em;
-  box-sizing: border-box;
+.keyboard-table td {
+  border: 1px solid #ccc;
+  padding: 4px;
+  min-width: 20px;
+  text-align: center;
+}
+
+.keyboard-count {
+  margin-top: 0.5em;
 }
 </style>
+

--- a/web/src/components/KeyboardView.vue
+++ b/web/src/components/KeyboardView.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue';
 
 const props = defineProps({
   layoutData: Object,
+  layoutName: String,
   total: Number,
 });
 
@@ -100,8 +101,9 @@ function hasRows() {
   <div>
     <h3>Keyboard Layout</h3>
     <p class="keyboard-count" v-if="typeof total === 'number'">
-      Showing first of {{ total }} keyboard layout{{ total === 1 ? '' : 's' }}
+      {{ total }} keyboard layout{{ total === 1 ? '' : 's' }} available
     </p>
+    <p v-if="layoutName" class="keyboard-name">{{ layoutName }}</p>
     <table v-if="hasRows()" class="keyboard-table">
       <tbody>
         <tr v-for="(row, rIdx) in rows" :key="rIdx">
@@ -110,7 +112,7 @@ function hasRows() {
       </tbody>
     </table>
     <div v-else>
-      <p>No keyboard layout available for this language.</p>
+      <p>No preview for this keyboard layout.</p>
     </div>
   </div>
 </template>
@@ -130,6 +132,9 @@ function hasRows() {
 
 .keyboard-count {
   margin-top: 0.5em;
+}
+.keyboard-name {
+  margin-top: 0.25em;
 }
 h3 {
   margin-bottom: 0.5em;

--- a/web/src/components/LanguageList.vue
+++ b/web/src/components/LanguageList.vue
@@ -4,10 +4,11 @@ import { ref, onMounted, computed } from 'vue';
 const languages = ref([]);
 const searchTerm = ref('');
 const emit = defineEmits(['language-selected']);
+const baseUrl = import.meta.env.BASE_URL;
 
 onMounted(async () => {
   try {
-    const response = await fetch('data/index.json');
+    const response = await fetch(`${baseUrl}data/index.json`);
     if (!response.ok) {
       throw new Error('Network response was not ok');
     }

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1,5 +1,8 @@
-import { createApp } from 'vue'
-import './style.css'
-import App from './App.vue'
+import { createApp } from 'vue';
+import './style.css';
+import App from './App.vue';
+import router from './router';
 
-createApp(App).mount('#app')
+const app = createApp(App);
+app.use(router);
+app.mount('#app');

--- a/web/src/router.js
+++ b/web/src/router.js
@@ -1,0 +1,11 @@
+import { createRouter, createWebHistory } from 'vue-router';
+import HomeView from './views/HomeView.vue';
+
+const router = createRouter({
+  history: createWebHistory(import.meta.env.BASE_URL),
+  routes: [
+    { path: '/:langCode?', name: 'home', component: HomeView },
+  ],
+});
+
+export default router;

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -1,0 +1,33 @@
+<script setup>
+import { ref, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import LanguageList from '../components/LanguageList.vue';
+import LanguageDetails from '../components/LanguageDetails.vue';
+
+const route = useRoute();
+const router = useRouter();
+const selectedLangCode = ref(route.params.langCode || null);
+
+watch(() => route.params.langCode, (newCode) => {
+  selectedLangCode.value = newCode || null;
+});
+
+function handleLanguageSelected(langCode) {
+  router.push({ path: `/${langCode}` });
+}
+</script>
+
+<template>
+  <main class="app-container">
+    <LanguageList @language-selected="handleLanguageSelected" />
+    <LanguageDetails :selected-lang-code="selectedLangCode" />
+  </main>
+</template>
+
+<style scoped>
+.app-container {
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  height: 100vh;
+}
+</style>


### PR DESCRIPTION
## Summary
- ignore mirrored data files copied into the web app during development
- guard against missing alphabet, keyboard, or audio JSON and load using base-aware paths
- add Vue Router so each language view is accessible via `/<code>`

## Testing
- `uv run ruff check .`
- `uv run mypy --install-types --non-interactive .`
- `npm test`
- `npm run predev`
- `npm run vite-dev -- --port 5177` (failed: Invalid Option)
- `npm run vite-dev -- --port 5177`

------
https://chatgpt.com/codex/tasks/task_e_68ab50e7067483279b29bd8f1d1fb5d2