### PR TITLE
Handle script-specific alphabet files across tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ uv run scripts/extract_alphabets.py
 
 The script clones the [kalenchukov/Alphabet](https://github.com/kalenchukov/Alphabet)
 Java project and stores JSON files for every available
-alphabet under `data/alphabets/`, named by ISO language code. If no sample text
+alphabet under `data/alphabets/`, named by ISO language code and script. If no sample text
 is available, frequency values default to zero and the language is recorded in
 `data/todo_languages.csv` for follow-up.
 
@@ -317,7 +317,7 @@ Derive an alphabet from an ICU locale's exemplar character set:
 uv run scripts/generate_alphabet_from_locale.py <code> --locale <locale>
 ```
 
-The script writes `data/alphabets/<code>.json`, using the locale's standard
+The script writes `data/alphabets/<code>-<script>.json`, using the locale's standard
 exemplar set for the base letters and populating frequency values from the
 Simia unigrams dataset when available. Locales without exemplar data are
 skipped. Exemplar entries spanning multiple code points are normalized and
@@ -332,7 +332,7 @@ uv run scripts/generate_alphabet_from_unigrams.py <code> --locale <locale> \
   --block <Unicode block>
 ```
 
-The script writes `data/alphabets/<code>.json`. To list missing codes:
+The script writes `data/alphabets/<code>-<script>.json`. To list missing codes:
 
 ```bash
 uv run scripts/missing_unigram_languages.py

--- a/__tests__/worldalphabets.test.js
+++ b/__tests__/worldalphabets.test.js
@@ -63,6 +63,12 @@ describe('worldalphabets', () => {
     expect(alphabet.script).toBe('Latn');
   });
 
+  it('should load alphabet file by script', async () => {
+    const alphabet = await loadAlphabet('mr', 'Latn');
+    expect(alphabet.script).toBe('Latn');
+    expect(alphabet.alphabetical).toContain('A');
+  });
+
   it('should return null for an invalid language code', async () => {
     const langInfo = await getLanguage('invalid-code');
     expect(langInfo).toBeNull();

--- a/tests/test_alphabets.py
+++ b/tests/test_alphabets.py
@@ -1,0 +1,13 @@
+from worldalphabets import get_language, load_alphabet
+
+
+def test_get_language_with_script() -> None:
+    lang = get_language("mr", script="Latn")
+    assert lang is not None
+    assert lang["script"] == "Latn"
+    assert "A" in lang["alphabetical"]
+
+
+def test_load_alphabet_with_script() -> None:
+    alphabet = load_alphabet("mr", "Latn")
+    assert "A" in alphabet.alphabetical

--- a/web/src/components/LanguageDetails.vue
+++ b/web/src/components/LanguageDetails.vue
@@ -41,10 +41,9 @@ watch(() => props.selectedLangCode, async (newLangCode) => {
   activeTab.value = 'alphabet';
 
   try {
-    // Fetch all data in parallel
-    const [indexRes, alphabetRes, audioIndexRes, layoutIndexRes] = await Promise.all([
+    // Fetch indexes in parallel
+    const [indexRes, audioIndexRes, layoutIndexRes] = await Promise.all([
       fetch(`${baseUrl}data/index.json`),
-      fetch(`${baseUrl}data/alphabets/${newLangCode}.json`),
       fetch(`${baseUrl}data/audio/index.json`),
       fetch(`${baseUrl}data/layouts/index.json`),
     ]);
@@ -55,12 +54,22 @@ watch(() => props.selectedLangCode, async (newLangCode) => {
     }
     const indexData = await indexRes.json();
     const langInfo = indexData.find(l => l.language === newLangCode);
+    let script = null;
     if (langInfo) {
       languageInfo.value = {
         name: langInfo['language-name'],
         direction: langInfo.direction === 'rtl' ? 'Right to Left' : 'Left to Right'
       };
+      if (Array.isArray(langInfo.scripts) && langInfo.scripts.length) {
+        script = langInfo.scripts[0];
+      }
     }
+
+    // Fetch alphabet after determining script
+    const alphabetPath = script
+      ? `${baseUrl}data/alphabets/${newLangCode}-${script}.json`
+      : `${baseUrl}data/alphabets/${newLangCode}.json`;
+    const alphabetRes = await fetch(alphabetPath);
 
     // Keyboard layouts
     if (layoutIndexRes.ok) {

--- a/web/src/components/LanguageList.vue
+++ b/web/src/components/LanguageList.vue
@@ -12,7 +12,14 @@ onMounted(async () => {
     if (!response.ok) {
       throw new Error('Network response was not ok');
     }
-    languages.value = await response.json();
+    const data = await response.json();
+    languages.value = data.sort((a, b) =>
+      a['language-name'].localeCompare(
+        b['language-name'],
+        undefined,
+        { sensitivity: 'base' },
+      ),
+    );
   } catch (error) {
     console.error('Failed to fetch languages:', error);
   }


### PR DESCRIPTION
## Summary
- Load alphabet JSON using `<code>-<script>` filenames in the web UI
- Clarify documentation about new alphabet filename format
- Add tests for Node and Python APIs with script-specific alphabets
- Sort the web language list alphabetically for easier browsing

## Testing
- `uv run ruff check tests/test_alphabets.py`
- `PYTHONPATH=src uv run mypy tests/test_alphabets.py`
- `uv run pytest`
- `npm test`
- `npm --prefix web run build`


------
https://chatgpt.com/codex/tasks/task_e_68af295c09dc83279f14fba4aa1d8618