### PR TITLE
Sync script-aware index and update README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,23 @@ Install the package:
 pip install worldalphabets
 ```
 
-To load the data in Python:
+To load the data in Python (omitting ``script`` uses the first script listed):
 
 ```python
-from worldalphabets import get_available_codes, load_alphabet
+from worldalphabets import get_available_codes, get_scripts, load_alphabet
 
 codes = get_available_codes()
 print("Loaded", len(codes), "alphabets")
 
-alphabet = load_alphabet("en")
-print(alphabet.uppercase[:5])  # ['A', 'B', 'C', 'D', 'E']
-print(alphabet.frequency['e'])
+alphabet = load_alphabet("en")  # defaults to first script (Latn)
+print("English uppercase:", alphabet.uppercase[:5])
+
+scripts = get_scripts("mr")
+print("Marathi scripts:", scripts)
+
+alphabet_mr = load_alphabet("mr", script=scripts[0])
+print("Marathi uppercase:", alphabet_mr.uppercase[:5])
+print("Marathi frequency for 'a':", alphabet_mr.frequency["a"])
 ```
 
 ### Node.js
@@ -43,14 +49,18 @@ const {
   getLowercase,
   getFrequency,
   getAvailableCodes,
+  getScripts,
 } = require('worldalphabets');
 
 async function main() {
   const codes = await getAvailableCodes();
   console.log('Available codes (first 5):', codes.slice(0, 5));
 
-  const uppercaseEn = await getUppercase('en');
-  console.log('English uppercase:', uppercaseEn);
+  const scriptsSr = await getScripts('sr');
+  console.log('Serbian scripts:', scriptsSr);
+
+  const uppercaseSr = await getUppercase('sr', scriptsSr[0]);
+  console.log('Serbian uppercase:', uppercaseSr);
 
   const lowercaseFr = await getLowercase('fr');
   console.log('French lowercase:', lowercaseFr);
@@ -72,8 +82,8 @@ If you have cloned the repository, you can use the module directly:
 const { getUppercase } = require('./index');
 
 async function main() {
-    const uppercaseEn = await getUppercase('en');
-    console.log('English uppercase:', uppercaseEn);
+    const uppercaseSr = await getUppercase('sr', 'Latn');
+    console.log('Serbian Latin uppercase:', uppercaseSr);
 }
 
 main();
@@ -84,7 +94,7 @@ main();
 The `examples/` directory contains small scripts demonstrating the library:
 
 - `examples/python/` holds Python snippets for printing alphabets, collecting
-  stats, and more.
+  stats, listing scripts, and more.
 - `examples/node/` includes similar examples for Node.js.
 
 ### Audio Samples
@@ -117,11 +127,15 @@ This library also provides an index of all available alphabets with additional m
 #### Python
 
 ```python
-from worldalphabets import get_index_data, get_language
+from worldalphabets import get_index_data, get_language, get_scripts
 
 # Get the entire index
 index = get_index_data()
 print(f"Index contains {len(index)} languages.")
+
+# Show available scripts for Serbian
+scripts = get_scripts("sr")
+print(f"Serbian scripts: {scripts}")
 
 # Load Marathi in the Latin script
 marathi_latn = get_language("mr", script="Latn")
@@ -132,12 +146,16 @@ print(f"First letters: {marathi_latn['alphabetical'][:5]}")
 #### Node.js
 
 ```javascript
-const { getIndexData, getLanguage } = require('worldalphabets');
+const { getIndexData, getLanguage, getScripts } = require('worldalphabets');
 
 async function main() {
   // Get the entire index
   const index = await getIndexData();
   console.log(`Index contains ${index.length} languages.`);
+
+  // Show available scripts for Serbian
+  const scripts = await getScripts('sr');
+  console.log(`Serbian scripts: ${scripts}`);
 
   // Load Marathi in the Latin script
   const marathiLatn = await getLanguage('mr', 'Latn');

--- a/examples/node/listScripts.js
+++ b/examples/node/listScripts.js
@@ -1,0 +1,10 @@
+// List available scripts for a language code.
+const { getScripts } = require('../..');
+
+async function main() {
+  const code = process.argv[2] || 'en';
+  const scripts = await getScripts(code);
+  console.log(`${code} scripts: ${scripts.join(', ')}`);
+}
+
+main();

--- a/examples/node/printAlphabet.js
+++ b/examples/node/printAlphabet.js
@@ -1,12 +1,14 @@
-// Print uppercase and lowercase letters for a language code.
+// Print uppercase and lowercase letters for a language code and script.
 const { getUppercase, getLowercase } = require('../..');
 
 async function main() {
   const code = process.argv[2] || 'en';
-  const upper = await getUppercase(code);
-  const lower = await getLowercase(code);
-  console.log(`${code} uppercase: ${upper.join(' ')}`);
-  console.log(`${code} lowercase: ${lower.join(' ')}`);
+  const script = process.argv[3];
+  const upper = await getUppercase(code, script);
+  const lower = await getLowercase(code, script);
+  const label = script ? `${code}-${script}` : code;
+  console.log(`${label} uppercase: ${upper.join(' ')}`);
+  console.log(`${label} lowercase: ${lower.join(' ')}`);
 }
 
 main();

--- a/examples/node/randomLetter.js
+++ b/examples/node/randomLetter.js
@@ -3,9 +3,10 @@ const { getLowercase, getUppercase } = require('../..');
 
 async function main() {
   const code = process.argv[2] || 'en';
-  let letters = await getLowercase(code);
+  const script = process.argv[3];
+  let letters = await getLowercase(code, script);
   if (!letters.length) {
-    letters = await getUppercase(code);
+    letters = await getUppercase(code, script);
   }
   const pick = letters[Math.floor(Math.random() * letters.length)];
   console.log(pick);

--- a/examples/python/list_scripts.py
+++ b/examples/python/list_scripts.py
@@ -1,0 +1,16 @@
+"""List available scripts for a language code."""
+from __future__ import annotations
+
+import sys
+
+from worldalphabets import get_scripts
+
+
+def main() -> None:
+    code = sys.argv[1] if len(sys.argv) > 1 else "en"
+    scripts = get_scripts(code)
+    print(f"{code} scripts: {', '.join(scripts)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/print_alphabet.py
+++ b/examples/python/print_alphabet.py
@@ -8,9 +8,11 @@ from worldalphabets import load_alphabet
 
 def main() -> None:
     code = sys.argv[1] if len(sys.argv) > 1 else "en"
-    alphabet = load_alphabet(code)
-    print(f"{code} uppercase: {' '.join(alphabet.uppercase)}")
-    print(f"{code} lowercase: {' '.join(alphabet.lowercase)}")
+    script = sys.argv[2] if len(sys.argv) > 2 else None
+    alphabet = load_alphabet(code, script=script)
+    label = f"{code}-{script}" if script else code
+    print(f"{label} uppercase: {' '.join(alphabet.uppercase)}")
+    print(f"{label} lowercase: {' '.join(alphabet.lowercase)}")
 
 
 if __name__ == "__main__":

--- a/examples/python/random_letter.py
+++ b/examples/python/random_letter.py
@@ -9,7 +9,8 @@ from worldalphabets import load_alphabet
 
 def main() -> None:
     code = sys.argv[1] if len(sys.argv) > 1 else "en"
-    alphabet = load_alphabet(code)
+    script = sys.argv[2] if len(sys.argv) > 2 else None
+    alphabet = load_alphabet(code, script=script)
     letters = alphabet.lowercase or alphabet.alphabetical
     print(random.choice(letters))
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,8 +10,18 @@ export function getUppercase(code: string, script?: string): Promise<string[]>;
 export function getLowercase(code: string, script?: string): Promise<string[]>;
 export function getFrequency(code: string, script?: string): Promise<Record<string, number>>;
 export function getAvailableCodes(): Promise<string[]>;
-export function getIndexData(): Promise<object[]>;
+export interface IndexEntry {
+  language: string;
+  'language-name': string;
+  'frequency-avail': boolean;
+  'script-type': string;
+  direction: string;
+  scripts?: string[];
+  keyboards?: string[];
+}
+export function getIndexData(): Promise<IndexEntry[]>;
 export function getLanguage(langCode: string, script?: string): Promise<Alphabet | null>;
+export function getScripts(langCode: string): Promise<string[]>;
 
 // Re-export all keyboard types and functions
 export * from './keyboards';

--- a/index.js
+++ b/index.js
@@ -116,6 +116,17 @@ async function getLanguage(langCode, script) {
   }
 }
 
+/**
+ * Lists available scripts for a language.
+ * @param {string} langCode - The ISO 639-1 language code.
+ * @returns {Promise<string[]>} A promise that resolves to an array of script codes.
+ */
+async function getScripts(langCode) {
+  const data = await getIndexData();
+  const entry = data.find((item) => item.language === langCode);
+  return entry && entry.scripts ? entry.scripts : [];
+}
+
 const keyboards = require('./keyboards');
 
 module.exports = {
@@ -127,6 +138,7 @@ module.exports = {
   getAvailableCodes,
   getIndexData,
   getLanguage,
+  getScripts,
   // Keyboards
   ...keyboards,
 };

--- a/src/worldalphabets/__init__.py
+++ b/src/worldalphabets/__init__.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from importlib.resources import files
 from typing import Dict, List
 
-from .helpers import get_index_data, get_language
+from .helpers import get_index_data, get_language, get_scripts
 from .keyboards import get_available_layouts, load_keyboard
 from .models.keyboard import KeyboardLayout, KeyEntry, LayerLegends, DeadKey, Ligature
 
@@ -48,6 +48,7 @@ __all__ = [
     "get_available_codes",
     "get_index_data",
     "get_language",
+    "get_scripts",
     # Keyboards
     "load_keyboard",
     "get_available_layouts",

--- a/src/worldalphabets/data/index.json
+++ b/src/worldalphabets/data/index.json
@@ -1,659 +1,1071 @@
 [
   {
+    "language": "ab",
+    "language-name": "Abkhazian",
+    "frequency-avail": true,
+    "script-type": "Cyrillic",
+    "direction": "ltr",
+    "scripts": [
+      "Cyrl"
+    ]
+  },
+  {
     "language": "af",
     "language-name": "Afrikaans",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "ak",
     "language-name": "Akan",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "am",
     "language-name": "Amharic",
     "frequency-avail": true,
-    "script-type": "Abugida",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Ethiopic",
+    "direction": "ltr",
+    "scripts": [
+      "Ethi"
+    ]
   },
   {
     "language": "ar",
     "language-name": "Arabic",
-    "frequency-avail": false,
-    "script-type": "AbjadorAbugida",
-    "direction": "rl",
-    "scripts": []
+    "frequency-avail": true,
+    "script-type": "Arabic",
+    "direction": "rtl",
+    "keyboards": [
+      "00000401",
+      "00010401",
+      "00020401"
+    ],
+    "scripts": [
+      "Arab"
+    ]
   },
   {
     "language": "ast",
     "language-name": "Asturian",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
+  },
+  {
+    "language": "ay",
+    "language-name": "Aymara",
+    "frequency-avail": true,
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "az",
     "language-name": "Azerbaijani",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "0000042c",
+      "0001042c"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "ba",
     "language-name": "Bashkir",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Cyrillic",
+    "direction": "ltr",
+    "keyboards": [
+      "0000046d"
+    ],
+    "scripts": [
+      "Cyrl"
+    ]
   },
   {
     "language": "ban",
     "language-name": "Balinese",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "bax",
     "language-name": "Bamun",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Bamum",
+    "direction": "ltr",
+    "scripts": [
+      "Bamu"
+    ]
   },
   {
     "language": "be",
     "language-name": "Belarusian",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Cyrillic",
+    "direction": "ltr",
+    "keyboards": [
+      "00000423"
+    ],
+    "scripts": [
+      "Cyrl"
+    ]
   },
   {
     "language": "bg",
     "language-name": "Bulgarian",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Cyrillic",
+    "direction": "ltr",
+    "keyboards": [
+      "00000402",
+      "00010402",
+      "00020402",
+      "00030402",
+      "00040402"
+    ],
+    "scripts": [
+      "Cyrl"
+    ]
   },
   {
     "language": "bku",
     "language-name": "Buhid",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "bm",
     "language-name": "Bambara",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "bn",
     "language-name": "Bengali",
     "frequency-avail": true,
-    "script-type": "Abugida",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Bangla",
+    "direction": "ltr",
+    "keyboards": [
+      "00000445"
+    ],
+    "scripts": [
+      "Beng"
+    ]
   },
   {
     "language": "bo",
     "language-name": "Tibetan",
     "frequency-avail": true,
-    "script-type": "Abugida",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Tibetan",
+    "direction": "ltr",
+    "keyboards": [
+      "00000451",
+      "00010451"
+    ],
+    "scripts": [
+      "Tibt"
+    ]
+  },
+  {
+    "language": "bs",
+    "language-name": "Bosnian",
+    "frequency-avail": true,
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "0000201a"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "bug",
     "language-name": "Buginese",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "000b0c00"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "bya",
     "language-name": "Batak",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "ca",
     "language-name": "Catalan",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "ceb",
     "language-name": "Cebuano",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "chr",
     "language-name": "Cherokee",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Cherokee",
+    "direction": "ltr",
+    "scripts": [
+      "Cher"
+    ]
   },
   {
     "language": "ckb",
     "language-name": "Central Kurdish",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Arabic",
+    "direction": "rtl",
+    "keyboards": [
+      "00000492"
+    ],
+    "scripts": [
+      "Arab"
+    ]
   },
   {
     "language": "cop",
     "language-name": "Coptic",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Coptic",
+    "direction": "ltr",
+    "scripts": [
+      "Copt"
+    ]
   },
   {
     "language": "cs",
     "language-name": "Czech",
-    "frequency-avail": false,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "frequency-avail": true,
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "00000405",
+      "00010405"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "cv",
     "language-name": "Chuvash",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Cyrillic",
+    "direction": "ltr",
+    "scripts": [
+      "Cyrl"
+    ]
+  },
+  {
+    "language": "cy",
+    "language-name": "Welsh",
+    "frequency-avail": true,
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "da",
     "language-name": "Danish",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "00000406"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "de",
     "language-name": "German",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "00000407",
+      "00000807",
+      "00010407"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "dz",
     "language-name": "Dzongkha",
     "frequency-avail": true,
-    "script-type": "Abugida",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Tibetan",
+    "direction": "ltr",
+    "keyboards": [
+      "00000c51"
+    ],
+    "scripts": [
+      "Tibt"
+    ]
   },
   {
     "language": "el",
     "language-name": "Greek",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Greek",
+    "direction": "ltr",
+    "keyboards": [
+      "00000408",
+      "00010408",
+      "00020408",
+      "00030408",
+      "00040408",
+      "00050408"
+    ],
+    "scripts": [
+      "Grek"
+    ]
   },
   {
     "language": "en",
     "language-name": "English",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "00000409",
+      "00000809",
+      "00004009",
+      "00010409",
+      "00020409"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "eo",
     "language-name": "Esperanto",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "es",
     "language-name": "Spanish",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "0000040a",
+      "0000080a"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "et",
     "language-name": "Estonian",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "00000425"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "eu",
     "language-name": "Basque",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "fa",
     "language-name": "Persian",
     "frequency-avail": true,
-    "script-type": "AbjadorAbugida",
-    "direction": "rl",
-    "scripts": []
+    "script-type": "Arabic",
+    "direction": "rtl",
+    "keyboards": [
+      "00000429",
+      "00050429"
+    ],
+    "scripts": [
+      "Arab"
+    ]
   },
   {
     "language": "fi",
     "language-name": "Finnish",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "0000040b",
+      "0001083b"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "fo",
     "language-name": "Faroese",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "00000438"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "fr",
     "language-name": "French",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "0000040c",
+      "0000080c",
+      "00000c0c",
+      "00001009",
+      "0000100c",
+      "0001040c",
+      "0002040c"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "fur",
     "language-name": "Friulian",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "ga",
     "language-name": "Irish",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "00001809"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "gd",
     "language-name": "Scottish Gaelic",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "00011809"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "gez",
     "language-name": "Geez",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Ethiopic",
+    "direction": "ltr",
+    "scripts": [
+      "Ethi"
+    ]
   },
   {
     "language": "gl",
     "language-name": "Galician",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
+  },
+  {
+    "language": "gn",
+    "language-name": "Guarani",
+    "frequency-avail": true,
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "00000474"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "gu",
     "language-name": "Gujarati",
     "frequency-avail": true,
-    "script-type": "Abugida",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Gujarati",
+    "direction": "ltr",
+    "keyboards": [
+      "00000447"
+    ],
+    "scripts": [
+      "Gujr"
+    ]
   },
   {
     "language": "gv",
     "language-name": "Manx",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "haw",
     "language-name": "Hawaiian",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "00000475"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "he",
     "language-name": "Hebrew",
     "frequency-avail": true,
-    "script-type": "Abjad",
-    "direction": "rl",
-    "scripts": []
+    "script-type": "Hebrew",
+    "direction": "rtl",
+    "keyboards": [
+      "0000040d",
+      "0002040d",
+      "0003040d"
+    ],
+    "scripts": [
+      "Hebr"
+    ]
   },
   {
     "language": "hi",
     "language-name": "Hindi",
     "frequency-avail": true,
-    "script-type": "Abugida",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Devanagari",
+    "direction": "ltr",
+    "scripts": [
+      "Deva"
+    ]
   },
   {
     "language": "hnn",
     "language-name": "Hanunoo",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
+  },
+  {
+    "language": "hr",
+    "language-name": "Croatian",
+    "frequency-avail": true,
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "ht",
     "language-name": "Haitian Creole",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "hu",
     "language-name": "Hungarian",
-    "frequency-avail": false,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "frequency-avail": true,
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "0000040e"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "hy",
     "language-name": "Armenian",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Armenian",
+    "direction": "ltr",
+    "scripts": [
+      "Armn"
+    ]
   },
   {
     "language": "ie",
     "language-name": "Interlingue",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "is",
     "language-name": "Icelandic",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "0000040f"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "it",
     "language-name": "Italian",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "00000410",
+      "00010410"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "ja",
     "language-name": "Japanese",
     "frequency-avail": true,
-    "script-type": "Logographic",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Japanese",
+    "direction": "ltr",
+    "keyboards": [
+      "00000411"
+    ],
+    "scripts": [
+      "Jpan"
+    ]
   },
   {
     "language": "jv",
     "language-name": "Javanese",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "00110c00"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "ka",
     "language-name": "Georgian",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Georgian",
+    "direction": "ltr",
+    "keyboards": [
+      "00000437",
+      "00010437",
+      "00020437",
+      "00030437",
+      "00040437"
+    ],
+    "scripts": [
+      "Geor"
+    ]
   },
   {
     "language": "kab",
     "language-name": "Kabyle",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "kk",
     "language-name": "Kazakh",
     "frequency-avail": true,
-    "script-type": "AbjadorAbugida",
-    "direction": "rl",
-    "scripts": []
+    "script-type": "Cyrillic",
+    "direction": "ltr",
+    "keyboards": [
+      "0000043f"
+    ],
+    "scripts": [
+      "Cyrl"
+    ]
   },
   {
     "language": "kl",
     "language-name": "Kalaallisut",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "km",
     "language-name": "Khmer",
     "frequency-avail": true,
-    "script-type": "Abugida",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Khmer",
+    "direction": "ltr",
+    "keyboards": [
+      "00000453",
+      "00010453"
+    ],
+    "scripts": [
+      "Khmr"
+    ]
   },
   {
     "language": "kn",
     "language-name": "Kannada",
     "frequency-avail": true,
-    "script-type": "Abugida",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Kannada",
+    "direction": "ltr",
+    "keyboards": [
+      "0000044b"
+    ],
+    "scripts": [
+      "Knda"
+    ]
   },
   {
     "language": "ko",
     "language-name": "Korean",
     "frequency-avail": true,
-    "script-type": "Logographic",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Korean",
+    "direction": "ltr",
+    "keyboards": [
+      "00000412"
+    ],
+    "scripts": [
+      "Kore"
+    ]
   },
   {
     "language": "ks",
     "language-name": "Kashmiri",
     "frequency-avail": true,
-    "script-type": "AbjadorAbugida",
-    "direction": "rl",
-    "scripts": []
+    "script-type": "Arabic",
+    "direction": "rtl",
+    "scripts": [
+      "Arab"
+    ]
   },
   {
     "language": "ksh",
     "language-name": "Colognian",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "ku",
     "language-name": "Kurdish",
     "frequency-avail": true,
-    "script-type": "AbjadorAbugida",
-    "direction": "rl",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "ky",
     "language-name": "Kyrgyz",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Cyrillic",
+    "direction": "ltr",
+    "scripts": [
+      "Cyrl"
+    ]
   },
   {
     "language": "la",
     "language-name": "Latin",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "lb",
     "language-name": "Luxembourgish",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "0000046e"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "lep",
     "language-name": "Lepcha",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Lepcha",
+    "direction": "ltr",
+    "scripts": [
+      "Lepc"
+    ]
   },
   {
     "language": "lif",
     "language-name": "Limbu",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Devanagari",
+    "direction": "ltr",
+    "scripts": [
+      "Deva"
+    ]
   },
   {
     "language": "lij",
     "language-name": "Ligurian",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "lis",
     "language-name": "Lisu",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Fraser",
+    "direction": "ltr",
+    "keyboards": [
+      "00070c00",
+      "00080c00"
+    ],
+    "scripts": [
+      "Lisu"
+    ]
   },
   {
     "language": "lo",
     "language-name": "Lao",
     "frequency-avail": true,
-    "script-type": "Abugida",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Lao",
+    "direction": "ltr",
+    "keyboards": [
+      "00000454"
+    ],
+    "scripts": [
+      "Laoo"
+    ]
   },
   {
     "language": "lt",
     "language-name": "Lithuanian",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "00010427"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "lv",
     "language-name": "Latvian",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "00000426",
+      "00010426",
+      "00020426"
+    ],
+    "scripts": [
+      "Latn"
+    ]
+  },
+  {
+    "language": "lzh",
+    "language-name": "Literary Chinese",
+    "frequency-avail": true,
+    "script-type": "Simplified",
+    "direction": "ltr",
+    "scripts": [
+      "Hans"
+    ]
   },
   {
     "language": "mg",
     "language-name": "Malagasy",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "mid",
     "language-name": "Mandaic",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "mk",
     "language-name": "Macedonian",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Cyrillic",
+    "direction": "ltr",
+    "keyboards": [
+      "0000042f"
+    ],
+    "scripts": [
+      "Cyrl"
+    ]
   },
   {
     "language": "ml",
     "language-name": "Malayalam",
     "frequency-avail": true,
-    "script-type": "Abugida",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Malayalam",
+    "direction": "ltr",
+    "keyboards": [
+      "0000044c"
+    ],
+    "scripts": [
+      "Mlym"
+    ]
   },
   {
     "language": "mn",
     "language-name": "Mongolian",
     "frequency-avail": false,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Cyrillic",
+    "direction": "ltr",
+    "keyboards": [
+      "00000850"
+    ],
+    "scripts": [
+      "Cyrl"
+    ]
   },
   {
     "language": "mo",
     "language-name": "Romanian",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "mr",
@@ -670,424 +1082,607 @@
     "language": "my",
     "language-name": "Burmese",
     "frequency-avail": true,
-    "script-type": "Abugida",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Myanmar",
+    "direction": "ltr",
+    "scripts": [
+      "Mymr"
+    ]
   },
   {
     "language": "mzn",
     "language-name": "Mazanderani",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Arabic",
+    "direction": "rtl",
+    "scripts": [
+      "Arab"
+    ]
   },
   {
     "language": "nds",
     "language-name": "Low German",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "ne",
     "language-name": "Nepali",
     "frequency-avail": true,
-    "script-type": "Abugida",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Devanagari",
+    "direction": "ltr",
+    "keyboards": [
+      "00000461"
+    ],
+    "scripts": [
+      "Deva"
+    ]
   },
   {
     "language": "nn",
     "language-name": "Norwegian Nynorsk",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "no",
     "language-name": "Norwegian",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "00000414",
+      "0000043b"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "nqo",
     "language-name": "N’Ko",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "N’Ko",
+    "direction": "rtl",
+    "keyboards": [
+      "00090c00"
+    ],
+    "scripts": [
+      "Nkoo"
+    ]
   },
   {
     "language": "nso",
     "language-name": "Northern Sotho",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "oc",
     "language-name": "Occitan",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "or",
     "language-name": "Odia",
     "frequency-avail": true,
-    "script-type": "Abugida",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Odia",
+    "direction": "ltr",
+    "keyboards": [
+      "00000448"
+    ],
+    "scripts": [
+      "Orya"
+    ]
   },
   {
     "language": "pl",
     "language-name": "Polish",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "00000415",
+      "00010415"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "ps",
     "language-name": "Pashto",
     "frequency-avail": true,
-    "script-type": "AbjadorAbugida",
-    "direction": "rl",
-    "scripts": []
+    "script-type": "Arabic",
+    "direction": "rtl",
+    "keyboards": [
+      "00000463"
+    ],
+    "scripts": [
+      "Arab"
+    ]
   },
   {
     "language": "pt",
     "language-name": "Portuguese",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "00000416",
+      "00000816",
+      "00010416"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "rej",
     "language-name": "Rejang",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "rm",
     "language-name": "Romansh",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "ro",
     "language-name": "Romanian",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "00000418",
+      "00010418",
+      "00020418"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "ru",
     "language-name": "Russian",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Cyrillic",
+    "direction": "ltr",
+    "keyboards": [
+      "00000419",
+      "00010419"
+    ],
+    "scripts": [
+      "Cyrl"
+    ]
   },
   {
     "language": "sa",
     "language-name": "Sanskrit",
     "frequency-avail": true,
-    "script-type": "Abugida",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Devanagari",
+    "direction": "ltr",
+    "scripts": [
+      "Deva"
+    ]
   },
   {
     "language": "sam",
     "language-name": "Samaritan Aramaic",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "saz",
     "language-name": "Saurashtra",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Saurashtra",
+    "direction": "ltr",
+    "scripts": [
+      "Saur"
+    ]
   },
   {
     "language": "sc",
     "language-name": "Sardinian",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "se",
     "language-name": "Northern Sami",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "sg",
     "language-name": "Sango",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "si",
     "language-name": "Sinhala",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Sinhala",
+    "direction": "ltr",
+    "keyboards": [
+      "0000045b"
+    ],
+    "scripts": [
+      "Sinh"
+    ]
   },
   {
     "language": "sl",
     "language-name": "Slovenian",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "00000424"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "sn",
     "language-name": "Shona",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "so",
     "language-name": "Somali",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "sr",
     "language-name": "Serbian",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Cyrillic",
+    "direction": "ltr",
+    "keyboards": [
+      "0000081a",
+      "00000c1a"
+    ],
+    "scripts": [
+      "Cyrl"
+    ]
   },
   {
     "language": "su",
     "language-name": "Sundanese",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "sv",
     "language-name": "Swedish",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "0000041d",
+      "0000083b"
+    ],
+    "scripts": [
+      "Latn"
+    ]
+  },
+  {
+    "language": "sw",
+    "language-name": "Swahili",
+    "frequency-avail": true,
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "syr",
     "language-name": "Syriac",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Syriac",
+    "direction": "rtl",
+    "keyboards": [
+      "0000045a"
+    ],
+    "scripts": [
+      "Syrc"
+    ]
   },
   {
     "language": "szl",
     "language-name": "Silesian",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "ta",
     "language-name": "Tamil",
     "frequency-avail": true,
-    "script-type": "Abugida",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Tamil",
+    "direction": "ltr",
+    "keyboards": [
+      "00000449"
+    ],
+    "scripts": [
+      "Taml"
+    ]
   },
   {
     "language": "tbw",
     "language-name": "Tagbanwa",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "te",
     "language-name": "Telugu",
     "frequency-avail": true,
-    "script-type": "Abugida",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Telugu",
+    "direction": "ltr",
+    "keyboards": [
+      "0000044a"
+    ],
+    "scripts": [
+      "Telu"
+    ]
   },
   {
     "language": "tg",
     "language-name": "Tajik",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Cyrillic",
+    "direction": "ltr",
+    "keyboards": [
+      "00000428"
+    ],
+    "scripts": [
+      "Cyrl"
+    ]
   },
   {
     "language": "th",
     "language-name": "Thai",
     "frequency-avail": true,
-    "script-type": "Abugida",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Thai",
+    "direction": "ltr",
+    "scripts": [
+      "Thai"
+    ]
   },
   {
     "language": "ti",
     "language-name": "Tigrinya",
     "frequency-avail": true,
-    "script-type": "Abugida",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Ethiopic",
+    "direction": "ltr",
+    "scripts": [
+      "Ethi"
+    ]
   },
   {
     "language": "tk",
     "language-name": "Turkmen",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "00000442"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "tl",
     "language-name": "Tagalog",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "tn",
     "language-name": "Tswana",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "tr",
     "language-name": "Turkish",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "tt",
     "language-name": "Tatar",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Cyrillic",
+    "direction": "ltr",
+    "keyboards": [
+      "00000444",
+      "00010444"
+    ],
+    "scripts": [
+      "Cyrl"
+    ]
   },
   {
     "language": "uk",
     "language-name": "Ukrainian",
     "frequency-avail": true,
-    "script-type": "Alphabet",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Cyrillic",
+    "direction": "ltr",
+    "keyboards": [
+      "00000422",
+      "00020422"
+    ],
+    "scripts": [
+      "Cyrl"
+    ]
   },
   {
     "language": "ur",
     "language-name": "Urdu",
     "frequency-avail": true,
-    "script-type": "AbjadorAbugida",
-    "direction": "rl",
-    "scripts": []
+    "script-type": "Arabic",
+    "direction": "rtl",
+    "keyboards": [
+      "00000420"
+    ],
+    "scripts": [
+      "Arab"
+    ]
   },
   {
     "language": "vai",
     "language-name": "Vai",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Vai",
+    "direction": "ltr",
+    "scripts": [
+      "Vaii"
+    ]
   },
   {
     "language": "vec",
     "language-name": "Venetian",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "wo",
     "language-name": "Wolof",
     "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
-  },
-  {
-    "language": "zh-classical",
-    "language-name": "zh-classical",
-    "frequency-avail": true,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "keyboards": [
+      "00000488"
+    ],
+    "scripts": [
+      "Latn"
+    ]
   },
   {
     "language": "zh-min-nan",
     "language-name": "Min",
     "frequency-avail": true,
-    "script-type": "Logographic",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Simplified",
+    "direction": "ltr",
+    "scripts": [
+      "Hans"
+    ]
   },
   {
     "language": "zh-yue",
     "language-name": "Yue",
     "frequency-avail": true,
-    "script-type": "Logographic",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Traditional",
+    "direction": "ltr",
+    "scripts": [
+      "Hant"
+    ]
   },
   {
     "language": "zh",
     "language-name": "Mandarin",
     "frequency-avail": true,
-    "script-type": "Logographic",
-    "direction": "lr",
-    "scripts": []
+    "script-type": "Simplified",
+    "direction": "ltr",
+    "scripts": [
+      "Hans"
+    ]
   },
   {
     "language": "zra",
     "language-name": "Kara (Korea)",
     "frequency-avail": false,
-    "script-type": "TBD",
-    "direction": "TBD",
-    "scripts": []
+    "script-type": "Latin",
+    "direction": "ltr",
+    "scripts": [
+      "Latn"
+    ]
   }
 ]

--- a/src/worldalphabets/helpers.py
+++ b/src/worldalphabets/helpers.py
@@ -1,6 +1,6 @@
 import json
 from importlib.resources import files
-from typing import Optional
+from typing import List, Optional
 
 INDEX_FILE = files("worldalphabets") / "data" / "index.json"
 ALPHABET_DIR = files("worldalphabets") / "data" / "alphabets"
@@ -51,3 +51,16 @@ def get_language(lang_code: str, script: Optional[str] = None) -> dict | None:
         return None
 
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def get_scripts(lang_code: str) -> List[str]:
+    """Return available script codes for ``lang_code``."""
+
+    entry = next(
+        (item for item in get_index_data() if item["language"] == lang_code),
+        None,
+    )
+    if entry is None:
+        return []
+    scripts = entry.get("scripts")
+    return scripts if scripts else []


### PR DESCRIPTION
## Summary
- Sync Python package index with up-to-date script metadata so languages default to a script when none provided
- Clarify README usage: omitting `script` uses first script and show how to list scripts

## Testing
- `uv run ruff check examples/python src/worldalphabets`
- `uv run mypy --install-types --non-interactive examples/python src/worldalphabets`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af502822bc832796a28e86e2c82b79