### PR TITLE
fix: avoid initial missing alphabet requests

### DIFF
--- a/web/src/components/LanguageDetails.vue
+++ b/web/src/components/LanguageDetails.vue
@@ -162,7 +162,7 @@ watch(() => props.selectedLangCode, async (newLangCode) => {
 }, { immediate: true });
 
 watch(selectedScript, async script => {
-  if (props.selectedLangCode) {
+  if (props.selectedLangCode && script) {
     await loadAlphabet(props.selectedLangCode, script);
   }
 });


### PR DESCRIPTION
## Summary
- avoid requesting generic alphabet JSON before script is known

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af8685589483279b90c3071b2b2a28