### PR TITLE
feat: add diacritic utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,31 @@ async function main() {
 main();
 ```
 
+### Diacritic Utilities
+
+Both interfaces provide helpers to work with diacritic marks.
+
+#### Python
+
+```python
+from worldalphabets import strip_diacritics, has_diacritics
+
+strip_diacritics("café")  # "cafe"
+has_diacritics("é")       # True
+```
+
+#### Node.js
+
+```javascript
+const { stripDiacritics, hasDiacritics } = require('worldalphabets');
+
+stripDiacritics('café'); // 'cafe'
+hasDiacritics('é');      // true
+```
+
+Use `characters_with_diacritics`/`charactersWithDiacritics` to extract letters
+with diacritic marks from a list.
+
 ### Examples
 
 The `examples/` directory contains small scripts demonstrating the library:

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,5 +25,9 @@ export function getIndexData(): Promise<IndexEntry[]>;
 export function getLanguage(langCode: string, script?: string): Promise<Alphabet | null>;
 export function getScripts(langCode: string): Promise<string[]>;
 
+export function stripDiacritics(text: string): string;
+export function hasDiacritics(char: string): boolean;
+export function charactersWithDiacritics(chars: string[]): string[];
+
 // Re-export all keyboard types and functions
 export * from './keyboards';

--- a/index.js
+++ b/index.js
@@ -139,6 +139,18 @@ async function getScripts(langCode) {
   return entry && entry.scripts ? entry.scripts : [];
 }
 
+function stripDiacritics(text) {
+  return text.normalize('NFD').replace(/\p{M}/gu, '');
+}
+
+function hasDiacritics(char) {
+  return stripDiacritics(char) !== char;
+}
+
+function charactersWithDiacritics(chars) {
+  return chars.filter((ch) => hasDiacritics(ch));
+}
+
 const keyboards = require('./keyboards');
 
 module.exports = {
@@ -152,6 +164,10 @@ module.exports = {
   getIndexData,
   getLanguage,
   getScripts,
+  // Diacritics
+  stripDiacritics,
+  hasDiacritics,
+  charactersWithDiacritics,
   // Keyboards
   ...keyboards,
 };

--- a/src/worldalphabets/__init__.py
+++ b/src/worldalphabets/__init__.py
@@ -8,6 +8,11 @@ from typing import Dict, List, Optional
 from .helpers import get_index_data, get_language, get_scripts
 from .keyboards import get_available_layouts, load_keyboard
 from .models.keyboard import KeyboardLayout, KeyEntry, LayerLegends, DeadKey, Ligature
+from .diacritics import (
+    strip_diacritics,
+    has_diacritics,
+    characters_with_diacritics,
+)
 
 ALPHABET_DIR = files("worldalphabets") / "data" / "alphabets"
 
@@ -51,6 +56,10 @@ __all__ = [
     "get_index_data",
     "get_language",
     "get_scripts",
+    # Diacritics
+    "strip_diacritics",
+    "has_diacritics",
+    "characters_with_diacritics",
     # Keyboards
     "load_keyboard",
     "get_available_layouts",

--- a/src/worldalphabets/diacritics.py
+++ b/src/worldalphabets/diacritics.py
@@ -1,0 +1,18 @@
+import unicodedata
+from typing import Iterable, List
+
+
+def strip_diacritics(text: str) -> str:
+    """Return ``text`` with all combining diacritic marks removed."""
+    normalized = unicodedata.normalize("NFD", text)
+    return "".join(ch for ch in normalized if not unicodedata.combining(ch))
+
+
+def has_diacritics(char: str) -> bool:
+    """Return ``True`` if ``char`` contains any diacritic marks."""
+    return char != strip_diacritics(char)
+
+
+def characters_with_diacritics(chars: Iterable[str]) -> List[str]:
+    """Return characters from ``chars`` that contain diacritic marks."""
+    return [c for c in chars if has_diacritics(c)]

--- a/tests/diacritics.test.js
+++ b/tests/diacritics.test.js
@@ -1,0 +1,21 @@
+const {
+  stripDiacritics,
+  hasDiacritics,
+  charactersWithDiacritics,
+} = require('../index');
+
+describe('diacritic helpers', () => {
+  test('stripDiacritics removes marks', () => {
+    expect(stripDiacritics('café')).toBe('cafe');
+  });
+
+  test('hasDiacritics detects marks', () => {
+    expect(hasDiacritics('é')).toBe(true);
+    expect(hasDiacritics('e')).toBe(false);
+  });
+
+  test('charactersWithDiacritics filters', () => {
+    expect(charactersWithDiacritics(['a', 'é', 'ö', 'b'])).toEqual(['é', 'ö']);
+  });
+});
+

--- a/tests/test_diacritics.py
+++ b/tests/test_diacritics.py
@@ -1,0 +1,20 @@
+from worldalphabets.diacritics import (
+    strip_diacritics,
+    has_diacritics,
+    characters_with_diacritics,
+)
+
+
+def test_strip_diacritics() -> None:
+    assert strip_diacritics("café") == "cafe"
+
+
+def test_has_diacritics() -> None:
+    assert has_diacritics("é")
+    assert not has_diacritics("e")
+
+
+def test_characters_with_diacritics() -> None:
+    chars = ["a", "é", "ö", "b"]
+    assert characters_with_diacritics(chars) == ["é", "ö"]
+


### PR DESCRIPTION
## Summary
- add strip/has/charactersWithDiacritics helpers for Node
- expose strip_diacritics and related helpers for Python
- document diacritic utilities in README

## Testing
- `uv run ruff check src/worldalphabets/diacritics.py src/worldalphabets/__init__.py tests/test_diacritics.py`
- `uv run mypy src/worldalphabets/diacritics.py src/worldalphabets/__init__.py tests/test_diacritics.py`
- `uv run pytest tests/test_diacritics.py`
- `npm test >/tmp/npm-test.log && tail -n 20 /tmp/npm-test.log`


------
https://chatgpt.com/codex/tasks/task_e_68c5e428b4788327a5a8d69b917fd079