### PR TITLE
feat: expose diacritic variants and language detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,63 @@ async function main() {
 main();
 ```
 
+### Diacritic Utilities
+
+Both interfaces provide helpers to work with diacritic marks.
+
+#### Python
+
+```python
+from worldalphabets import strip_diacritics, has_diacritics
+
+strip_diacritics("café")  # "cafe"
+has_diacritics("é")       # True
+```
+
+#### Node.js
+
+```javascript
+const { stripDiacritics, hasDiacritics } = require('worldalphabets');
+
+stripDiacritics('café'); // 'cafe'
+hasDiacritics('é');      // true
+```
+
+Use `characters_with_diacritics`/`charactersWithDiacritics` to extract letters
+with diacritic marks from a list.
+
+Use `get_diacritic_variants`/`getDiacriticVariants` to list base letters and
+their diacritic forms for a given language.
+
+```python
+from worldalphabets import get_diacritic_variants
+
+get_diacritic_variants("pl", "Latn")["L"]  # ["L", "Ł"]
+```
+
+```javascript
+const { getDiacriticVariants } = require('worldalphabets');
+
+getDiacriticVariants('pl').then((v) => v.L); // ['L', 'Ł']
+```
+
+### Language Detection
+
+To guess possible languages for a string, use
+`detect_languages`/`detectLanguages`.
+
+```python
+from worldalphabets import detect_languages
+
+detect_languages("Żółć")  # ['pl', ...]
+```
+
+```javascript
+const { detectLanguages } = require('worldalphabets');
+
+detectLanguages('Żółć').then((codes) => console.log(codes));
+```
+
 ### Examples
 
 The `examples/` directory contains small scripts demonstrating the library:

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,5 +25,15 @@ export function getIndexData(): Promise<IndexEntry[]>;
 export function getLanguage(langCode: string, script?: string): Promise<Alphabet | null>;
 export function getScripts(langCode: string): Promise<string[]>;
 
+export function stripDiacritics(text: string): string;
+export function hasDiacritics(char: string): boolean;
+export function charactersWithDiacritics(chars: string[]): string[];
+export function getDiacriticVariants(
+  code: string,
+  script?: string
+): Promise<Record<string, string[]>>;
+// Language detection
+export function detectLanguages(text: string): Promise<string[]>;
+
 // Re-export all keyboard types and functions
 export * from './keyboards';

--- a/src/worldalphabets/diacritics.py
+++ b/src/worldalphabets/diacritics.py
@@ -1,0 +1,50 @@
+import unicodedata
+from typing import Dict, Iterable, List, Set
+
+
+def strip_diacritics(text: str) -> str:
+    """Return ``text`` with diacritic marks removed."""
+
+    result: List[str] = []
+    for ch in text:
+        normalized = unicodedata.normalize("NFD", ch)
+        base = "".join(c for c in normalized if not unicodedata.combining(c))
+        if base == ch:
+            name = unicodedata.name(ch, "")
+            if " WITH " in name:
+                base_name = name.split(" WITH ")[0]
+                try:
+                    base = unicodedata.lookup(base_name)
+                except KeyError:
+                    pass
+        result.append(base)
+    return "".join(result)
+
+
+def has_diacritics(char: str) -> bool:
+    """Return ``True`` if ``char`` contains any diacritic marks."""
+    return char != strip_diacritics(char)
+
+
+def characters_with_diacritics(chars: Iterable[str]) -> List[str]:
+    """Return characters from ``chars`` that contain diacritic marks."""
+    return [c for c in chars if has_diacritics(c)]
+
+
+def diacritic_variants(chars: Iterable[str]) -> Dict[str, List[str]]:
+    """Group ``chars`` by base form and return those with variants.
+
+    The result maps a base character to a sorted list of characters in ``chars``
+    that share that base and include at least one diacritic form.
+    """
+
+    groups: Dict[str, Set[str]] = {}
+    for ch in chars:
+        base = strip_diacritics(ch)
+        groups.setdefault(base, set()).add(ch)
+
+    return {
+        base: sorted(list(variants))
+        for base, variants in groups.items()
+        if len(variants) > 1
+    }

--- a/tests/detect.test.js
+++ b/tests/detect.test.js
@@ -1,0 +1,8 @@
+const { detectLanguages } = require('../index');
+
+describe('language detection', () => {
+  test('detectLanguages finds candidates', async () => {
+    const langs = await detectLanguages('Żółć');
+    expect(langs).toContain('pl');
+  });
+});

--- a/tests/diacritics.test.js
+++ b/tests/diacritics.test.js
@@ -1,0 +1,28 @@
+const {
+  stripDiacritics,
+  hasDiacritics,
+  charactersWithDiacritics,
+  getDiacriticVariants,
+} = require('../index');
+
+describe('diacritic helpers', () => {
+  test('stripDiacritics removes marks', () => {
+    expect(stripDiacritics('café')).toBe('cafe');
+  });
+
+  test('hasDiacritics detects marks', () => {
+    expect(hasDiacritics('é')).toBe(true);
+    expect(hasDiacritics('e')).toBe(false);
+  });
+
+  test('charactersWithDiacritics filters', () => {
+    expect(charactersWithDiacritics(['a', 'é', 'ö', 'b'])).toEqual(['é', 'ö']);
+  });
+
+  test('getDiacriticVariants groups characters', async () => {
+    const variants = await getDiacriticVariants('pl');
+    expect(variants.L).toEqual(['L', 'Ł']);
+    expect(variants.l).toEqual(['l', 'ł']);
+  });
+});
+

--- a/tests/test_detect_languages.py
+++ b/tests/test_detect_languages.py
@@ -1,0 +1,6 @@
+from worldalphabets import detect_languages
+
+
+def test_detect_languages() -> None:
+    langs = detect_languages("Żółć")
+    assert "pl" in langs

--- a/tests/test_diacritics.py
+++ b/tests/test_diacritics.py
@@ -1,0 +1,26 @@
+from worldalphabets import (
+    strip_diacritics,
+    has_diacritics,
+    characters_with_diacritics,
+    get_diacritic_variants,
+)
+
+
+def test_strip_diacritics() -> None:
+    assert strip_diacritics("café") == "cafe"
+
+
+def test_has_diacritics() -> None:
+    assert has_diacritics("é")
+    assert not has_diacritics("e")
+
+
+def test_characters_with_diacritics() -> None:
+    chars = ["a", "é", "ö", "b"]
+    assert characters_with_diacritics(chars) == ["é", "ö"]
+
+
+def test_get_diacritic_variants() -> None:
+    variants = get_diacritic_variants("pl", "Latn")
+    assert variants["L"] == ["L", "Ł"]
+    assert variants["l"] == ["l", "ł"]


### PR DESCRIPTION
## Summary
- add helpers to list alphabet letters with diacritic variants
- implement basic language detection based on available alphabets
- document new diacritic utilities and language detection in README

## Testing
- `uv run ruff check src/worldalphabets/diacritics.py src/worldalphabets/__init__.py tests/test_diacritics.py tests/test_detect_languages.py`
- `uv run mypy src/worldalphabets/diacritics.py src/worldalphabets/__init__.py tests/test_diacritics.py tests/test_detect_languages.py`
- `uv run pytest tests/test_diacritics.py tests/test_detect_languages.py`
- `npm test >/tmp/npm-test.log && tail -n 20 /tmp/npm-test.log`


------
https://chatgpt.com/codex/tasks/task_e_68c5e428b4788327a5a8d69b917fd079